### PR TITLE
v1264 StateBar: Implements HP, MP, XP, FPS and SystemTime

### DIFF
--- a/src/game/GameProcMain.cpp
+++ b/src/game/GameProcMain.cpp
@@ -5275,6 +5275,14 @@ void CGameProcMain::ParseChattingCommand(const std::string & szCmd) {
         CAPISocket::MP_AddWord(byBuff, iOffset, (fZ * 10));
 
         s_pSocket->Send(byBuff, iOffset);
+    } else if (0 == lstrcmp(szCmds[0], "systemgametimeon")) {
+        if (m_pUIStateBarAndMiniMap) {
+            m_pUIStateBarAndMiniMap->SetSystemTimeVisibility(true);
+        }
+    } else if (0 == lstrcmp(szCmds[0], "systemgametimeoff")) {
+        if (m_pUIStateBarAndMiniMap) {
+            m_pUIStateBarAndMiniMap->SetSystemTimeVisibility(false);
+        }
     }
 
     e_ChatCmd eCmd = CMD_UNKNOWN;

--- a/src/game/UIStateBar.cpp
+++ b/src/game/UIStateBar.cpp
@@ -28,10 +28,17 @@
 
 CUIStateBar::CUIStateBar() {
     m_pText_Position = NULL;
+    m_pText_HP = NULL;
+    m_pText_MP = NULL;
+    m_pText_Exp = NULL;
+
     m_pProgress_HP = NULL;
     m_pProgress_MSP = NULL;
     m_pProgress_ExpC = NULL;
     m_pProgress_ExpP = NULL;
+
+    m_pText_Fps = NULL;
+    m_pText_SystemTime = NULL;
 
     // ¹Ì´Ï¸Ê...
     m_pGroup_MiniMap = NULL;
@@ -78,10 +85,15 @@ void CUIStateBar::Release() {
     CN3UIBase::Release();
 
     m_pText_Position = NULL;
+    m_pText_HP = NULL;
+    m_pText_MP = NULL;
+    m_pText_Exp = NULL;
     m_pProgress_HP = NULL;
     m_pProgress_MSP = NULL;
     m_pProgress_ExpC = NULL;
     m_pProgress_ExpP = NULL;
+    m_pText_Fps = NULL;
+    m_pText_SystemTime = NULL;
 
     // ¹Ì´Ï¸Ê...
     m_pGroup_MiniMap = NULL;
@@ -110,6 +122,18 @@ bool CUIStateBar::Load(HANDLE hFile) {
     }
     m_pText_Position = (CN3UIString *)(this->GetChildByID("Text_Position"));
     __ASSERT(m_pText_Position, "NULL UI Component!!");
+
+    m_pText_HP = (CN3UIString *)(this->GetChildByID("Text_HP"));
+    __ASSERT(m_pText_Position, "NULL UI Component!!");
+    m_pText_MP = (CN3UIString *)(this->GetChildByID("Text_MSP"));
+    __ASSERT(m_pText_Position, "NULL UI Component!!");
+    m_pText_Exp = (CN3UIString *)(this->GetChildByID("Text_ExpP"));
+    __ASSERT(m_pText_Position, "NULL UI Component!!");
+
+    m_pText_Fps = (CN3UIString *)(this->GetChildByID("string_fps"));
+    __ASSERT(m_pText_Fps, "NULL UI Component!!");
+    m_pText_SystemTime = (CN3UIString *)(this->GetChildByID("SystemTime"));
+    __ASSERT(m_pText_SystemTime, "NULL UI Component!!");
 
     // TODO: Fix this and implement proper state bar.
     GetChildByID("Progress_HP_lasting")->SetVisible(false);
@@ -196,6 +220,19 @@ void CUIStateBar::UpdateExp(int iExp, int iExpNext, bool bUpdateImmediately) {
     } else {
         m_pProgress_ExpP->SetCurValue(iPercentage, 0.3f, 100.0f);
     }
+
+    char szExp[64];
+
+    float textExp = 0.00;
+
+    if (iExp <= 0) {
+        textExp = 0.00;
+    } else {
+        textExp = 100 * iExp / iExpNext;
+    }
+
+    sprintf(szExp, "%.2f%%", textExp);
+    m_pText_Exp->SetString(szExp);
 }
 
 void CUIStateBar::UpdateMSP(int iMSP, int iMSPMax, bool bUpdateImmediately) {
@@ -214,6 +251,10 @@ void CUIStateBar::UpdateMSP(int iMSP, int iMSPMax, bool bUpdateImmediately) {
     } else {
         m_pProgress_MSP->SetCurValue(iPercentage, 0.3f, 100.0f);
     }
+
+    char szMP[64];
+    sprintf(szMP, "%i / %i", iMSP, iMSPMax);
+    m_pText_MP->SetString(szMP);
 }
 
 void CUIStateBar::UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately) {
@@ -229,6 +270,10 @@ void CUIStateBar::UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately) {
     } else {
         m_pProgress_HP->SetCurValue(iPercentage, 0.3f, 100.0f);
     }
+
+    char szHP[64];
+    sprintf(szHP, "%i / %i", iHP, iHPMax);
+    m_pText_HP->SetString(szHP);
 }
 
 void CUIStateBar::UpdatePosition(const __Vector3 & vPos, float fYaw) {
@@ -245,9 +290,43 @@ void CUIStateBar::UpdatePosition(const __Vector3 & vPos, float fYaw) {
     m_fYawPlayer = fYaw;
 }
 
+void CUIStateBar::UpdateFPS(float fps) {
+    if (NULL == m_pText_Fps) {
+        return;
+    }
+
+    char szPos[64];
+    sprintf(szPos, "%.0f", fps);
+    m_pText_Fps->SetString(szPos);
+}
+
+void CUIStateBar::UpdateSystemTime() {
+    if (NULL == m_pText_SystemTime) {
+        return;
+    }
+
+    time_t      timer;
+    char        buffer[9];
+    struct tm * tm_info;
+
+    timer = time(NULL);
+    tm_info = localtime(&timer);
+
+    strftime(buffer, 9, "%H:%M:%S", tm_info);
+    m_pText_SystemTime->SetString(buffer);
+}
+
 void CUIStateBar::Render() {
     if (false == m_bVisible) {
         return;
+    }
+
+    float        fTime = CN3Base::TimeGet();
+    static float fTimePrevFps = CN3Base::TimeGet();
+    if (fTime > fTimePrevFps + 1.0f) {
+        fTimePrevFps = fTime;
+        UpdateFPS(CN3Base::s_fFrmPerSec);
+        UpdateSystemTime();
     }
 
     CN3UIBase::Render();

--- a/src/game/UIStateBar.cpp
+++ b/src/game/UIStateBar.cpp
@@ -28,29 +28,33 @@
 
 CUIStateBar::CUIStateBar() {
     m_pText_Position = NULL;
-    m_pText_HP = NULL;
-    m_pText_MP = NULL;
-    m_pText_Exp = NULL;
 
     m_pProgress_HP = NULL;
     m_pProgress_MSP = NULL;
     m_pProgress_ExpC = NULL;
     m_pProgress_ExpP = NULL;
 
-    m_pText_Fps = NULL;
-    m_pText_SystemTime = NULL;
-
     // ¹Ì´Ï¸Ê...
     m_pGroup_MiniMap = NULL;
     m_pImage_Map = NULL;
     m_pBtn_ZoomIn = NULL;
     m_pBtn_ZoomOut = NULL;
+
+    m_pText_HP = NULL;
+    m_pText_MSP = NULL;
+    m_pText_ExpP = NULL;
+    m_pText_Fps = NULL;
+    m_pText_SystemTime = NULL;
+
+    m_bShowSystemTime = false;
+
     memset(m_vArrows, 0, sizeof(m_vArrows));
     m_fZoom = 6.0f;
     m_fMapSizeX = 0.0f;
     m_fMapSizeZ = 0.0f;
     m_fYawPlayer = 0;
     m_vPosPlayer.Zero();
+    m_fFPSValue = 0.0f;
 
     m_pMagic.clear();
 }
@@ -85,21 +89,25 @@ void CUIStateBar::Release() {
     CN3UIBase::Release();
 
     m_pText_Position = NULL;
-    m_pText_HP = NULL;
-    m_pText_MP = NULL;
-    m_pText_Exp = NULL;
     m_pProgress_HP = NULL;
     m_pProgress_MSP = NULL;
     m_pProgress_ExpC = NULL;
     m_pProgress_ExpP = NULL;
-    m_pText_Fps = NULL;
-    m_pText_SystemTime = NULL;
 
     // ¹Ì´Ï¸Ê...
     m_pGroup_MiniMap = NULL;
     m_pImage_Map = NULL;
     m_pBtn_ZoomIn = NULL;
     m_pBtn_ZoomOut = NULL;
+
+    m_pText_HP = NULL;
+    m_pText_MSP = NULL;
+    m_pText_ExpP = NULL;
+    m_pText_Fps = NULL;
+    m_pText_SystemTime = NULL;
+
+    m_bShowSystemTime = false;
+
     memset(m_vArrows, 0, sizeof(m_vArrows));
     m_fZoom = 6.0f;
     m_fMapSizeX = 0.0f;
@@ -122,18 +130,6 @@ bool CUIStateBar::Load(HANDLE hFile) {
     }
     m_pText_Position = (CN3UIString *)(this->GetChildByID("Text_Position"));
     __ASSERT(m_pText_Position, "NULL UI Component!!");
-
-    m_pText_HP = (CN3UIString *)(this->GetChildByID("Text_HP"));
-    __ASSERT(m_pText_Position, "NULL UI Component!!");
-    m_pText_MP = (CN3UIString *)(this->GetChildByID("Text_MSP"));
-    __ASSERT(m_pText_Position, "NULL UI Component!!");
-    m_pText_Exp = (CN3UIString *)(this->GetChildByID("Text_ExpP"));
-    __ASSERT(m_pText_Position, "NULL UI Component!!");
-
-    m_pText_Fps = (CN3UIString *)(this->GetChildByID("string_fps"));
-    __ASSERT(m_pText_Fps, "NULL UI Component!!");
-    m_pText_SystemTime = (CN3UIString *)(this->GetChildByID("SystemTime"));
-    __ASSERT(m_pText_SystemTime, "NULL UI Component!!");
 
     // TODO: Fix this and implement proper state bar.
     GetChildByID("Progress_HP_lasting")->SetVisible(false);
@@ -174,6 +170,25 @@ bool CUIStateBar::Load(HANDLE hFile) {
         __ASSERT(m_pBtn_ZoomIn, "NULL UI Component!!");
         m_pBtn_ZoomOut = (CN3UIButton *)(m_pGroup_MiniMap->GetChildByID("Btn_ZoomIn"));
         __ASSERT(m_pBtn_ZoomOut, "NULL UI Component!!");
+    }
+
+    m_pText_HP = (CN3UIString *)(this->GetChildByID("Text_HP"));
+    __ASSERT(m_pText_Position, "NULL UI Component!!");
+    m_pText_MSP = (CN3UIString *)(this->GetChildByID("Text_MSP"));
+    __ASSERT(m_pText_Position, "NULL UI Component!!");
+    m_pText_ExpP = (CN3UIString *)(this->GetChildByID("Text_ExpP"));
+    __ASSERT(m_pText_Position, "NULL UI Component!!");
+
+    m_pText_Fps = (CN3UIString *)(this->GetChildByID("string_fps"));
+    __ASSERT(m_pText_Fps, "NULL UI Component!!");
+    if (m_pText_Fps) {
+        m_pText_Fps->SetString("");
+    }
+
+    m_pText_SystemTime = (CN3UIString *)(this->GetChildByID("SystemTime"));
+    __ASSERT(m_pText_SystemTime, "NULL UI Component!!");
+    if (m_pText_SystemTime) {
+        m_pText_SystemTime->SetString("");
     }
 
     return true;
@@ -221,18 +236,9 @@ void CUIStateBar::UpdateExp(int iExp, int iExpNext, bool bUpdateImmediately) {
         m_pProgress_ExpP->SetCurValue(iPercentage, 0.3f, 100.0f);
     }
 
-    char szExp[64];
-
-    float textExp = 0.00;
-
-    if (iExp <= 0) {
-        textExp = 0.00;
-    } else {
-        textExp = 100 * iExp / iExpNext;
+    if (m_pText_ExpP) {
+        m_pText_ExpP->SetString(std::to_string(iPercentage) + "%");
     }
-
-    sprintf(szExp, "%.2f%%", textExp);
-    m_pText_Exp->SetString(szExp);
 }
 
 void CUIStateBar::UpdateMSP(int iMSP, int iMSPMax, bool bUpdateImmediately) {
@@ -252,9 +258,9 @@ void CUIStateBar::UpdateMSP(int iMSP, int iMSPMax, bool bUpdateImmediately) {
         m_pProgress_MSP->SetCurValue(iPercentage, 0.3f, 100.0f);
     }
 
-    char szMP[64];
-    sprintf(szMP, "%i / %i", iMSP, iMSPMax);
-    m_pText_MP->SetString(szMP);
+    if (m_pText_MSP) {
+        m_pText_MSP->SetString(std::to_string(iMSP) + " / " + std::to_string(iMSPMax));
+    }
 }
 
 void CUIStateBar::UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately) {
@@ -271,9 +277,9 @@ void CUIStateBar::UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately) {
         m_pProgress_HP->SetCurValue(iPercentage, 0.3f, 100.0f);
     }
 
-    char szHP[64];
-    sprintf(szHP, "%i / %i", iHP, iHPMax);
-    m_pText_HP->SetString(szHP);
+    if (m_pText_HP) {
+        m_pText_HP->SetString(std::to_string(iHP) + " / " + std::to_string(iHPMax));
+    }
 }
 
 void CUIStateBar::UpdatePosition(const __Vector3 & vPos, float fYaw) {
@@ -281,8 +287,8 @@ void CUIStateBar::UpdatePosition(const __Vector3 & vPos, float fYaw) {
         return;
     }
 
-    char szPos[64];
-    sprintf(szPos, "%.1f, %.1f", vPos.x, vPos.z);
+    char szPos[64]{};
+    sprintf(szPos, "%d, %d", (int)vPos.x, (int)vPos.z);
     m_pText_Position->SetString(szPos);
 
     // ¹Ì´Ï¸Ê.
@@ -290,43 +296,9 @@ void CUIStateBar::UpdatePosition(const __Vector3 & vPos, float fYaw) {
     m_fYawPlayer = fYaw;
 }
 
-void CUIStateBar::UpdateFPS(float fps) {
-    if (NULL == m_pText_Fps) {
-        return;
-    }
-
-    char szPos[64];
-    sprintf(szPos, "%.0f", fps);
-    m_pText_Fps->SetString(szPos);
-}
-
-void CUIStateBar::UpdateSystemTime() {
-    if (NULL == m_pText_SystemTime) {
-        return;
-    }
-
-    time_t      timer;
-    char        buffer[9];
-    struct tm * tm_info;
-
-    timer = time(NULL);
-    tm_info = localtime(&timer);
-
-    strftime(buffer, 9, "%H:%M:%S", tm_info);
-    m_pText_SystemTime->SetString(buffer);
-}
-
 void CUIStateBar::Render() {
     if (false == m_bVisible) {
         return;
-    }
-
-    float        fTime = CN3Base::TimeGet();
-    static float fTimePrevFps = CN3Base::TimeGet();
-    if (fTime > fTimePrevFps + 1.0f) {
-        fTimePrevFps = fTime;
-        UpdateFPS(CN3Base::s_fFrmPerSec);
-        UpdateSystemTime();
     }
 
     CN3UIBase::Render();
@@ -491,6 +463,27 @@ void CUIStateBar::Tick() {
 
     TickMiniMap();   // ¸Ê ÀÌ¹ÌÁö...
     TickMagicIcon(); // ¾ÆÀÌÄÜ Ã³¸®..
+
+    m_fFPSValue += s_fSecPerFrm;
+    if (m_fFPSValue > 1.0f) {
+        char szBuff[12]{};
+        sprintf(szBuff, "%.1f", s_fFrmPerSec);
+        m_pText_Fps->SetString(szBuff);
+        m_fFPSValue = 0.0f;
+    }
+
+    if (m_bShowSystemTime) {
+        char szBuff[12]{};
+        sprintf(szBuff, "%.1f", CN3Base::TimeGet());
+
+        // The official client implements this as the line above.
+        // However printing actual system time as per @xGuTeK PR is not a bad idea either.
+        // Leaving it here as a comment in order to stick to the official behavior for now.
+        //time_t timer = time(NULL);
+        //strftime(szBuff, sizeof(szBuff), "%H:%M:%S", localtime(&timer));
+
+        m_pText_SystemTime->SetString(szBuff);
+    }
 }
 
 void CUIStateBar::TickMiniMap() {

--- a/src/game/UIStateBar.cpp
+++ b/src/game/UIStateBar.cpp
@@ -659,6 +659,14 @@ bool CUIStateBar::ToggleMiniMap() {
     return !bVisible;
 }
 
+// Turn ON/OFF with chat command: /systemgametimeon or /systemgametimeoff
+void CUIStateBar::SetSystemTimeVisibility(bool bVisible) {
+    m_bShowSystemTime = bVisible;
+    if (!bVisible) {
+        m_pText_SystemTime->SetString("");
+    }
+}
+
 void CUIStateBar::AddMagic(__TABLE_UPC_SKILL * pSkill, float fDuration) {
     // TODO: Change instances like these to std::format once upgrading to cpp20:
     // https://en.cppreference.com/w/cpp/utility/format/format

--- a/src/game/UIStateBar.h
+++ b/src/game/UIStateBar.h
@@ -24,11 +24,6 @@ typedef typename std::list<__DurationMagicImg *>::iterator it_MagicImg;
 class CUIStateBar : public CN3UIBase {
   protected:
     CN3UIString *   m_pText_Position;
-    CN3UIString *   m_pText_HP;
-    CN3UIString *   m_pText_MP;
-    CN3UIString *   m_pText_Exp;
-    CN3UIString *   m_pText_Fps;
-    CN3UIString *   m_pText_SystemTime;
     CN3UIProgress * m_pProgress_HP;
     CN3UIProgress * m_pProgress_MSP;
     CN3UIProgress * m_pProgress_ExpC;
@@ -40,11 +35,21 @@ class CUIStateBar : public CN3UIBase {
     CN3UIButton * m_pBtn_ZoomIn;
     CN3UIButton * m_pBtn_ZoomOut;
 
+    CN3UIString * m_pText_HP;
+    CN3UIString * m_pText_MSP;
+    CN3UIString * m_pText_ExpP;
+    CN3UIString * m_pText_Fps;
+    CN3UIString * m_pText_SystemTime;
+
+    bool m_bShowSystemTime;
+
     float     m_fZoom; // 지도의 배율..
     float     m_fMapSizeX;
     float     m_fMapSizeZ;
     float     m_fYawPlayer;
     __Vector3 m_vPosPlayer;
+
+    float m_fFPSValue;
 
     __VertexTransformedColor  m_vArrows[6]; // 플레이어 위치 화살표..
     std::list<__PositionInfo> m_Positions;
@@ -70,9 +75,6 @@ class CUIStateBar : public CN3UIBase {
     void UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately);
 
     void UpdatePosition(const __Vector3 & vPos, float fYaw);
-
-    void UpdateFPS(const float fps);
-    void UpdateSystemTime();
 
     void ZoomSet(float fZoom);
     void PositionInfoAdd(int iID, const __Vector3 & vPos, D3DCOLOR crID, bool bDrawTop);

--- a/src/game/UIStateBar.h
+++ b/src/game/UIStateBar.h
@@ -24,6 +24,11 @@ typedef typename std::list<__DurationMagicImg *>::iterator it_MagicImg;
 class CUIStateBar : public CN3UIBase {
   protected:
     CN3UIString *   m_pText_Position;
+    CN3UIString *   m_pText_HP;
+    CN3UIString *   m_pText_MP;
+    CN3UIString *   m_pText_Exp;
+    CN3UIString *   m_pText_Fps;
+    CN3UIString *   m_pText_SystemTime;
     CN3UIProgress * m_pProgress_HP;
     CN3UIProgress * m_pProgress_MSP;
     CN3UIProgress * m_pProgress_ExpC;
@@ -65,6 +70,9 @@ class CUIStateBar : public CN3UIBase {
     void UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately);
 
     void UpdatePosition(const __Vector3 & vPos, float fYaw);
+
+    void UpdateFPS(const float fps);
+    void UpdateSystemTime();
 
     void ZoomSet(float fZoom);
     void PositionInfoAdd(int iID, const __Vector3 & vPos, D3DCOLOR crID, bool bDrawTop);

--- a/src/game/UIStateBar.h
+++ b/src/game/UIStateBar.h
@@ -69,6 +69,7 @@ class CUIStateBar : public CN3UIBase {
     void  TickMiniMap();
 
     bool ToggleMiniMap();
+    void SetSystemTimeVisibility(bool bVisible);
 
     void UpdateExp(int iExp, int iExpNext, bool bUpdateImmediately);
     void UpdateMSP(int iMSP, int iMSPMax, bool bUpdateImmediately);


### PR DESCRIPTION
### Description

This PR implements the following StateBar elements as per official:
+ Load new v1264 UI elements.
+ Display HP, MP, XP, FPS and SystemTime.
+ Display coordinates as integers instead of floats as per official.
+ Move UpdateFPS and UpdateSystemTime from Render to Tick and inline them.
+ Reorder member variables in a logical order to keep it as close as possible to the official reversed engineered client structures layout.
+ Implement changing system time visibility via chat command with "/systemtimeon" and "/systemtimeoff".

Authored by @xGuTeK and @stevewgr.