### PR TITLE
Create Notice.txt file if not exists.

### DIFF
--- a/src/server/Ebenezer/EbenezerDlg.h
+++ b/src/server/Ebenezer/EbenezerDlg.h
@@ -88,7 +88,7 @@ class CEbenezerDlg : public CDialog {
     void    Send_KnightsMember(int index, char * pBuf, int len, int zone = 100);
     BOOL    AISocketConnect(int zone, int flag = 0);
     int     GetRegionNpcIn(C3DMap * pMap, int region_x, int region_z, char * buff, int & t_count);
-    BOOL    LoadNoticeData();
+    bool    LoadNoticeData();
     int     GetZoneIndex(int zonenumber);
     int     GetRegionNpcList(C3DMap * pMap, int region_x, int region_z, char * nid_buff, int & t_count,
                              int nType = 0);                      // Region All Npcs nid Packaging Function

--- a/src/server/Ebenezer/StdAfx.h
+++ b/src/server/Ebenezer/StdAfx.h
@@ -20,5 +20,16 @@
 #include <afxtempl.h>
 #include <afxdb.h>
 
+#include <map>
+#include <set>
+#include <list>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.


### PR DESCRIPTION
### Description

This PR improves loading Notice.txt file behavior. It was annoying that every time we lunch the server it complains about this file to be missing. So instead we create it as empty file, so people know of its existence and we don't see annoying error.

+ Write it with portable stl code.
+ Improve also error handling.