### PR TITLE
Cleanup UINotice implementation (Co-authored by xGuTeK)

### DIFF
--- a/src/game/GameProcMain.cpp
+++ b/src/game/GameProcMain.cpp
@@ -4480,6 +4480,10 @@ bool CGameProcMain::CommandToggleUIInventory() {
         return bNeedOpen;
     }
 
+    if (m_pUINotice->IsVisible()) {
+        m_pUINotice->Close();
+    }
+
     if (m_pUIInventory->IsVisible()) {
         m_pUIInventory->Close(true);
         return bNeedOpen;
@@ -4514,11 +4518,44 @@ bool CGameProcMain::CommandToggleUISkillTree() {
         if (m_pUIWareHouseDlg->IsVisible()) {
             m_pUIWareHouseDlg->LeaveWareHouseState();
         }
+        if (m_pUINotice->IsVisible()) {
+            m_pUINotice->Close();
+        }
 
         s_pUIMgr->SetFocusedUI(m_pUISkillTreeDlg);
         m_pUISkillTreeDlg->Open();
     } else {
         m_pUISkillTreeDlg->Close();
+    }
+
+    return bNeedOpen;
+}
+
+bool CGameProcMain::CommandToggleUINotice() {
+    bool bNeedOpen = !(m_pUINotice->IsVisible());
+
+    if (m_pSubProcPerTrade->m_ePerTradeState != PER_TRADE_STATE_NONE) {
+        return bNeedOpen;
+    }
+
+    if (bNeedOpen) {
+        if (m_pUIInventory->IsVisible()) {
+            m_pUIInventory->Close();
+        }
+        if (m_pUITransactionDlg->IsVisible()) {
+            m_pUITransactionDlg->LeaveTransactionState();
+        }
+        if (m_pUIWareHouseDlg->IsVisible()) {
+            m_pUIWareHouseDlg->LeaveWareHouseState();
+        }
+        if (m_pUISkillTreeDlg->IsVisible()) {
+            m_pUISkillTreeDlg->Close();
+        }
+
+        s_pUIMgr->SetFocusedUI(m_pUINotice);
+        m_pUINotice->Open();
+    } else {
+        m_pUINotice->Close();
     }
 
     return bNeedOpen;
@@ -4696,26 +4733,41 @@ void CGameProcMain::MsgRecv_Notice(DataPack * pDataPack, int & iOffset) {
         m_pUINotice->RemoveNotice();
     }
 
+    bool bStrContainHashSymbol = false;
+
     int iNoticeCount = CAPISocket::Parse_GetByte(pDataPack->m_pData, iOffset);
     for (int i = 0; i < iNoticeCount; i++) {
         int iStrLen = CAPISocket::Parse_GetByte(pDataPack->m_pData, iOffset);
+
         if (iStrLen <= 0) {
             continue;
         }
 
         std::string szNotice;
         CAPISocket::Parse_GetString(pDataPack->m_pData, iOffset, szNotice, iStrLen);
+
         if (m_pUINotice) {
-            m_pUINotice->m_Texts.push_back(szNotice);
+            char lastCharacter = szNotice.back();
+
+            if (!bStrContainHashSymbol && lastCharacter != '#') { // EventText not found -> Add to NoticeText
+                m_pUINotice->m_TextsNotices.push_back(szNotice);
+            } else if (!bStrContainHashSymbol &&
+                       lastCharacter == '#') { // Last character is # -> Add to NoticeText -> Next line is EventText
+                bStrContainHashSymbol = true;
+                m_pUINotice->m_TextsNotices.push_back(szNotice.substr(0, szNotice.length() - 1));
+            } else if (bStrContainHashSymbol) { // Add text to EventText
+                m_pUINotice->m_Texts.push_back(szNotice);
+            }
         }
     }
 
     if (m_pUINotice && iNoticeCount > 0) {
         m_pUINotice->GenerateText();
+        m_pUINotice->TipOfTheDay();
 
         RECT rc = m_pUINotice->GetRegion();
-        int  x = (CN3Base::s_CameraData.vp.Width / 2) - (rc.right - rc.left) / 2;
-        int  y = (CN3Base::s_CameraData.vp.Height / 2) - (rc.bottom - rc.top) / 2;
+        int  x = (CN3Base::s_CameraData.vp.Width - (rc.right - rc.left));
+        int  y = (10);
         m_pUINotice->SetPos(x, y);
         m_pUINotice->SetVisible(true);
     }

--- a/src/game/GameProcMain.h
+++ b/src/game/GameProcMain.h
@@ -223,6 +223,7 @@ class CGameProcMain : public CGameProcedure {
     bool CommandToggleWalkRun();
     bool CommandToggleUISkillTree();
     bool CommandToggleUIMiniMap();
+    bool CommandToggleUINotice();
 
     void CommandMove(e_MoveDirection eMD, bool bStartOrEnd); // 움직이는 방향(전후진, 멈춤), 움직이기 시작하는가?
     void CommandEnableAttackContinous(bool bEnable, CPlayerBase * pTarget);

--- a/src/game/UINotice.cpp
+++ b/src/game/UINotice.cpp
@@ -10,6 +10,7 @@
 #include "N3Base/N3UIString.h"
 #include "N3Base/N3UIScrollBar.h"
 #include "N3Base/N3UIButton.h"
+#include "N3Base/N3SndObj.h"
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -17,17 +18,60 @@
 
 CUINotice::CUINotice() {
     m_pText_Notice = NULL;
-    m_pScrollBar = NULL;
-    m_pBtn_OK = NULL;
+    m_pTextEvent = NULL;
+    m_pBtn_Quit = NULL;
+    m_pTextTip = NULL;
+    m_pTextEvent_Name = NULL;
+    sEventName.clear();
+    sTextTip.clear();
+
+    m_bOpenningNow = false;
+    m_bClosingNow = false;
+    m_fMoveDelta = 0;
 }
 
 CUINotice::~CUINotice() {
     m_Texts.clear();
+    m_TextsNotices.clear();
 }
 
 void CUINotice::Release() {
     m_Texts.clear();
+    m_TextsNotices.clear();
+    sEventName.clear();
+    sTextTip.clear();
     CN3UIBase::Release();
+}
+
+void CUINotice::Open() {
+
+    SetState(UI_STATE_COMMON_NONE);
+
+    SetVisible(true);
+    this->SetPos(CN3Base::s_CameraData.vp.Width, 10);
+    m_fMoveDelta = 0;
+    m_bOpenningNow = true;
+    m_bClosingNow = false;
+
+    if (m_pSnd_OpenUI) {
+        m_pSnd_OpenUI->Play();
+    }
+}
+
+void CUINotice::Close() {
+
+    SetState(UI_STATE_COMMON_NONE);
+
+    RECT rc = this->GetRegion();
+    this->SetPos(CN3Base::s_CameraData.vp.Width - (rc.right - rc.left), 10);
+
+    m_fMoveDelta = 0;
+    m_bOpenningNow = false;
+    m_bClosingNow = true;
+
+    if (m_pSnd_CloseUI) {
+        m_pSnd_CloseUI->Play();
+    }
 }
 
 bool CUINotice::Load(HANDLE hFile) {
@@ -36,12 +80,10 @@ bool CUINotice::Load(HANDLE hFile) {
     }
 
     m_pText_Notice = (CN3UIString *)GetChildByID("Text_Notice");
-    m_pScrollBar = (CN3UIScrollBar *)GetChildByID("ScrollBar");
-    m_pBtn_OK = (CN3UIButton *)GetChildByID("Btn_OK");
-
-    if (m_pScrollBar) {
-        m_pScrollBar->SetRange(0, 100);
-    }
+    m_pBtn_Quit = (CN3UIButton *)GetChildByID("btn_quit");
+    m_pTextEvent_Name = (CN3UIString *)GetChildByID("text_event_name");
+    m_pTextTip = (CN3UIString *)GetChildByID("text_tip");
+    m_pTextEvent = (CN3UIString *)GetChildByID("text_event");
 
     return true;
 }
@@ -51,21 +93,12 @@ bool CUINotice::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
         return false;
     }
 
-    //s_CameraData.vp;  //불러 오는 과정을 살펴본다
-    //DWORD mm = s_CameraData.vp.Height;
-    //DWORD ss = s_CameraData.vp.Width;
-
     if (dwMsg == UIMSG_BUTTON_CLICK) {
-        if (pSender == m_pBtn_OK) {
+        if (pSender == m_pBtn_Quit) {
             if (m_pText_Notice) {
                 m_pText_Notice->SetString("");
             }
-            SetVisible(false);
-        }
-    } else if (dwMsg == UIMSG_SCROLLBAR_POS) {
-        if (pSender == m_pScrollBar) {
-            // 스크롤바에 맞는 채팅 Line 설정
-            int iCurLinePos = m_pScrollBar->GetCurrentPos();
+            Close();
         }
     }
 
@@ -77,11 +110,10 @@ void CUINotice::GenerateText() {
         return;
     }
 
-    // 글자수를 센다..
-    int       iTextLen = 0;
-    it_String it = m_Texts.begin(), itEnd = m_Texts.end();
-    for (; it != itEnd; it++) {
-        iTextLen += it->size() + 3; // LineFeed, Carriage return
+    int iTextLen = 0;
+
+    for (auto & itString : m_TextsNotices) {
+        iTextLen += itString.size() + 3; // LineFeed, Carriage return
     }
 
     if (iTextLen <= 0) {
@@ -89,23 +121,109 @@ void CUINotice::GenerateText() {
     }
 
     std::vector<char> szBuff(iTextLen * 2, 0);
-
-    // 글자들을 붙이고  // LineFeed, Carriage return 을 붙인다.
-    it = m_Texts.begin();
-    itEnd = m_Texts.end();
-    for (; it != itEnd; it++) {
-        lstrcat(&szBuff[0], it->c_str());
+    for (auto & itString : m_TextsNotices) {
+        lstrcat(&szBuff[0], itString.c_str());
         lstrcat(&szBuff[0], "\n");
     }
 
-    m_pText_Notice->SetString(&(szBuff[0])); // 글자 적용..
+    m_pText_Notice->SetString(&(szBuff[0]));
+}
+
+void CUINotice::TipOfTheDay() {
+    if (NULL == m_pText_Notice) {
+        return;
+    }
+
+    int  iTextLen = 0;
+    bool tipOfTheDayEnabled = false;
+
+    for (auto & itString : m_Texts) {
+        iTextLen += itString.size() + 3; // LineFeed, Carriage return
+    }
+
+    if (iTextLen <= 0) {
+        tipOfTheDayEnabled = true;
+    }
+
+    if (!tipOfTheDayEnabled) {
+        std::vector<char> szBuff(iTextLen * 2, 0);
+
+        for (auto & itString : m_Texts) {
+            lstrcat(&szBuff[0], itString.c_str());
+            lstrcat(&szBuff[0], "\n");
+        }
+
+        m_pTextEvent->SetString(&(szBuff[0])); //Set Event text
+
+    } else {
+
+        srand((unsigned)time(NULL));
+        int randomTip = 5001 + rand() % 32;
+
+        ::_LoadStringFromResource(5034, sEventName);
+        m_pTextEvent_Name->SetString(sEventName);
+
+        ::_LoadStringFromResource(randomTip, sTextTip);
+        m_pTextTip->SetString(sTextTip);
+    }
+}
+
+void CUINotice::Tick() {
+    if (!m_bVisible) {
+        return;
+    }
+
+    if (m_bOpenningNow) {
+        POINT ptCur = this->GetPos();
+        RECT  rc = this->GetRegion();
+        float fWidth = (float)(rc.right - rc.left);
+
+        float fDelta = 5000.0f * CN3Base::s_fSecPerFrm;
+        fDelta *= (fWidth - m_fMoveDelta) / fWidth;
+        if (fDelta < 2.0f) {
+            fDelta = 2.0f;
+        }
+        m_fMoveDelta += fDelta;
+
+        int iXLimit = CN3Base::s_CameraData.vp.Width - (int)fWidth;
+        ptCur.x = CN3Base::s_CameraData.vp.Width - (int)m_fMoveDelta;
+        if (ptCur.x <= iXLimit) {
+            ptCur.x = iXLimit;
+            m_bOpenningNow = false;
+        }
+
+        this->SetPos(ptCur.x, ptCur.y);
+    } else if (m_bClosingNow) {
+        POINT ptCur = this->GetPos();
+        RECT  rc = this->GetRegion();
+        float fWidth = (float)(rc.right - rc.left);
+
+        float fDelta = 5000.0f * CN3Base::s_fSecPerFrm;
+        fDelta *= (fWidth - m_fMoveDelta) / fWidth;
+        if (fDelta < 2.0f) {
+            fDelta = 2.0f;
+        }
+        m_fMoveDelta += fDelta;
+
+        int iXLimit = CN3Base::s_CameraData.vp.Width;
+        ptCur.x = CN3Base::s_CameraData.vp.Width - (int)(fWidth - m_fMoveDelta);
+        if (ptCur.x >= iXLimit) {
+            ptCur.x = iXLimit;
+            m_bClosingNow = false;
+
+            this->SetVisibleWithNoSound(false, false, true);
+        }
+
+        this->SetPos(ptCur.x, ptCur.y);
+    }
+    CN3UIBase::Tick();
 }
 
 bool CUINotice::OnKeyPress(int iKey) {
     switch (iKey) {
     case DIK_ESCAPE:
     case DIK_RETURN:
-        ReceiveMessage(m_pBtn_OK, UIMSG_BUTTON_CLICK);
+        ReceiveMessage(m_pBtn_Quit, UIMSG_BUTTON_CLICK);
         return true;
     }
 
@@ -123,4 +241,5 @@ void CUINotice::SetVisible(bool bVisible) {
 
 void CUINotice::RemoveNotice() {
     m_Texts.clear();
+    m_TextsNotices.clear();
 }

--- a/src/game/UINotice.h
+++ b/src/game/UINotice.h
@@ -12,18 +12,31 @@ typedef typename std::list<std::string>::iterator it_String;
 
 class CUINotice : public CN3UIBase {
   public:
-    class CN3UIString *    m_pText_Notice;
-    class CN3UIScrollBar * m_pScrollBar;
-    class CN3UIButton *    m_pBtn_OK;
+    class CN3UIString * m_pText_Notice;
+    class CN3UIString * m_pTextTip;
+    class CN3UIString * m_pTextEvent_Name;
+    class CN3UIString * m_pTextEvent;
+    class CN3UIButton * m_pBtn_Quit;
 
     std::list<std::string> m_Texts;
+    std::list<std::string> m_TextsNotices;
+    std::string            sEventName;
+    std::string            sTextTip;
+
+    bool  m_bOpenningNow;
+    bool  m_bClosingNow;
+    float m_fMoveDelta;
 
   public:
     void RemoveNotice();
     void SetVisible(bool bVisible);
     bool OnKeyPress(int iKey);
     void GenerateText();
+    void TipOfTheDay();
     void Release();
+    void Open();
+    void Close();
+    void Tick();
 
     bool Load(HANDLE hFile);
     bool ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg);

--- a/src/game/UINotice.h
+++ b/src/game/UINotice.h
@@ -12,27 +12,24 @@ typedef typename std::list<std::string>::iterator it_String;
 
 class CUINotice : public CN3UIBase {
   public:
-    class CN3UIString * m_pText_Notice;
-    class CN3UIString * m_pTextTip;
-    class CN3UIString * m_pTextEvent_Name;
+    class CN3UIString * m_pTextNotice;
     class CN3UIString * m_pTextEvent;
-    class CN3UIButton * m_pBtn_Quit;
+    class CN3UIString * m_pTextEventName;
+    class CN3UIString * m_pTextTip;
+    class CN3UIButton * m_pBtnQuit;
 
-    std::list<std::string> m_Texts;
-    std::list<std::string> m_TextsNotices;
-    std::string            sEventName;
-    std::string            sTextTip;
-
+    float m_fMoveDelta;
     bool  m_bOpenningNow;
     bool  m_bClosingNow;
-    float m_fMoveDelta;
+
+    std::list<std::string> m_Texts;
+    std::list<std::string> m_TextsEvent;
 
   public:
     void RemoveNotice();
     void SetVisible(bool bVisible);
     bool OnKeyPress(int iKey);
     void GenerateText();
-    void TipOfTheDay();
     void Release();
     void Open();
     void Close();


### PR DESCRIPTION
### Description

+ Check for loaded components properly using assertions.
+ Trigger closing and opening now events properly for better ui transition.
+ Parse packet as how it's done officially.
+ Move TipOfTheDay to GenerateText where it's belong as per official.
+ Don't use magic numbers and use loading resources with ids from resource.h.
+ Allow also enter numpad work to close UI.
+ Simplify certain constructs.

Continuation to UINotice implementation aiming to replicate official behavior of the game.

This PR is initially authored by @xGuTeK.