### PR TITLE
Increasing `MAX_ITEM_EXTENSION` to read in table 23 that is being reference at runtime.

### DIFF
--- a/src/game/GameDef.h
+++ b/src/game/GameDef.h
@@ -915,7 +915,7 @@ typedef struct __TABLE_ITEM_BASIC // 장착 아이템에 관한 리소스 레코드...
     BYTE bySellGroup; // 32 상인이 파는데에 대한 그룹..
 } TABLE_ITEM_BASIC;
 
-const int MAX_ITEM_EXTENSION = 22; // 확장 아이템 테이블 갯수.
+const int MAX_ITEM_EXTENSION = 23; // 확장 아이템 테이블 갯수.
 const int LIMIT_FX_DAMAGE = 64;
 const int ITEM_UNIQUE = 4;
 const int ITEM_LIMITED_EXHAUST = 17;


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

After starting a Karus character one of the first things I did was kill and try to loot a Kecoon Scout. When trying to loot the monster I hit the following issue with a NULL pointer due to a missing `s_pTbl_Items_Exts` entry. Since the Item Extension 23 TBL is already present in the game assets I propose increasing the `MAX_ITEM_EXTENSION` variable to 23 in order to address the issue.

![issue-1](https://user-images.githubusercontent.com/680880/211130119-c1f66a2e-9b35-4677-b92c-45e36f5507b9.png)

💔Thank you!
