### PR TITLE
`N3_WARP_LIST` bySubOp switched on to prevent double warp UI from showing.

### DIFF
--- a/src/game/GameProcMain.cpp
+++ b/src/game/GameProcMain.cpp
@@ -6386,27 +6386,30 @@ void CGameProcMain::MsgRecv_WarpList(DataPack * pDataPack, int & iOffset) // ¿öÇ
     int iStrLen = 0;
 
     BYTE bySubOp = CAPISocket::Parse_GetByte(pDataPack->m_pData, iOffset);
-    int  iListCount = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);
-    for (int i = 0; i < iListCount; i++) {
-        __WarpInfo WI;
+    switch (bySubOp) {
+    case 1:
+        int iListCount = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);
+        for (int i = 0; i < iListCount; i++) {
+            __WarpInfo WI;
 
-        WI.iID = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                  // ¿öÇÁ ID
-        iStrLen = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                 // ÀÌ¸§ ±æÀÌ
-        CAPISocket::Parse_GetString(pDataPack->m_pData, iOffset, WI.szName, iStrLen);      // ÀÌ¸§
-        iStrLen = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                 // µ¿ÀÇ¹® ±æÀÌ
-        CAPISocket::Parse_GetString(pDataPack->m_pData, iOffset, WI.szAgreement, iStrLen); // µ¿ÀÇ¹®
-        WI.iZone = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                // Á¸¹øÈ£
-        WI.iMaxUser = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);             // ÃÖ´ë À¯Àú Ä«¿îÆ®.
-        WI.iGold = CAPISocket::Parse_GetDword(pDataPack->m_pData, iOffset);                // µ·
-        WI.vPos.x = (CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset)) / 10.0f;     // ÁÂÇ¥
-        WI.vPos.z = (CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset)) / 10.0f;     //
-        WI.vPos.y = (CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset)) / 10.0f;     //
+            WI.iID = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                  // ¿öÇÁ ID
+            iStrLen = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                 // ÀÌ¸§ ±æÀÌ
+            CAPISocket::Parse_GetString(pDataPack->m_pData, iOffset, WI.szName, iStrLen);      // ÀÌ¸§
+            iStrLen = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                 // µ¿ÀÇ¹® ±æÀÌ
+            CAPISocket::Parse_GetString(pDataPack->m_pData, iOffset, WI.szAgreement, iStrLen); // µ¿ÀÇ¹®
+            WI.iZone = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);                // Á¸¹øÈ£
+            WI.iMaxUser = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);             // ÃÖ´ë À¯Àú Ä«¿îÆ®.
+            WI.iGold = CAPISocket::Parse_GetDword(pDataPack->m_pData, iOffset);                // µ·
+            WI.vPos.x = (CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset)) / 10.0f;     // ÁÂÇ¥
+            WI.vPos.z = (CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset)) / 10.0f;     //
+            WI.vPos.y = (CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset)) / 10.0f;     //
 
-        m_pUIWarp->InfoAdd(WI);
+            m_pUIWarp->InfoAdd(WI);
+        }
+
+        m_pUIWarp->UpdateList();
+        m_pUIWarp->SetVisible(true);
     }
-
-    m_pUIWarp->UpdateList();
-    m_pUIWarp->SetVisible(true);
 }
 
 /*

--- a/src/game/GameProcMain.cpp
+++ b/src/game/GameProcMain.cpp
@@ -4070,6 +4070,16 @@ void CGameProcMain::MsgSend_Warp() // ¿öÇÁ - Á¸ÀÌµ¿ÀÌ µÉ¼öµµ ÀÖ´Ù..
         return;
     }
 
+    m_pUIWarp->m_CurrWI = WI;
+    if (CGameBase::s_pPlayer->m_InfoExt.iGold < m_pUIWarp->m_CurrWI.iGold) {
+        std::string szMsg;
+        ::_LoadStringFromResource(IDS_WARP_REQUIRED_COINS, szMsg); // 7612
+        char szMsgBuff[400]{};
+        sprintf(szMsgBuff, szMsg.c_str(), m_pUIWarp->m_CurrWI.szName.c_str(), m_pUIWarp->m_CurrWI.iGold);
+        MsgOutput(szMsgBuff, 0xffff3b3b);
+        return;
+    }
+
     BYTE byBuff[8];
     int  iOffset = 0;
 
@@ -6386,8 +6396,7 @@ void CGameProcMain::MsgRecv_WarpList(DataPack * pDataPack, int & iOffset) // ¿öÇ
     int iStrLen = 0;
 
     BYTE bySubOp = CAPISocket::Parse_GetByte(pDataPack->m_pData, iOffset);
-    switch (bySubOp) {
-    case 1:
+    if (bySubOp == 1) {
         int iListCount = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);
         for (int i = 0; i < iListCount; i++) {
             __WarpInfo WI;
@@ -6409,6 +6418,22 @@ void CGameProcMain::MsgRecv_WarpList(DataPack * pDataPack, int & iOffset) // ¿öÇ
 
         m_pUIWarp->UpdateList();
         m_pUIWarp->SetVisible(true);
+    } else if (bySubOp == 2) {
+        BYTE bySubSubOp = CAPISocket::Parse_GetByte(pDataPack->m_pData, iOffset);
+        switch (bySubSubOp) {
+        case 1:
+            std::string szMsg;
+            ::_LoadStringFromResource(IDS_WARP_ARRIVED, szMsg); // 6606
+            __WarpInfo WI = m_pUIWarp->m_CurrWI;
+            if (WI.szName.empty()) {
+                return;
+            }
+
+            char szMsgBuff[400]{};
+            sprintf(szMsgBuff, szMsg.c_str(), WI.szName.c_str());
+            MsgOutput(szMsgBuff, 0xffffff00);
+            break;
+        }
     }
 }
 

--- a/src/game/UIWarp.h
+++ b/src/game/UIWarp.h
@@ -21,6 +21,9 @@ struct __WarpInfo {
 typedef typename std::list<__WarpInfo>::iterator it_WI;
 
 class CUIWarp : public CN3UIBase {
+  public:
+    __WarpInfo m_CurrWI;
+
   protected:
     class CN3UIButton * m_pBtn_Ok;
     class CN3UIButton * m_pBtn_Cancel;

--- a/src/game/res/Resource.h
+++ b/src/game/res/Resource.h
@@ -514,6 +514,8 @@
 #define IDS_DEAD_REVIVAL_MESSAGE                 6603
 #define IDS_DEAD_LOW_LEVEL                       6604
 #define IDS_INVEN_WEIGHT                         6605
+#define IDS_WARP_ARRIVED                         6606
+#define IDS_WARP_REQUIRED_COINS                  7612
 #define IDS_LEVELGUIDE_SEARCH_WARNING            10100
 #define IDS_NATIONSELECT_MSGBOX_SELECTION        10420
 #define IDS_NATIONSELECT_DESCRIPTION_KA          10421


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Fixing issue where the wrap list would show up again after the player teleports. This is because the client isn't handling the `bySubOp` for the `N3_WARP_LIST` packet.

💔Thank you!
