### PR TITLE
Fix formatting coins with commas.

### DIFF
--- a/src/engine/N3Base/My_3DStruct.h
+++ b/src/engine/N3Base/My_3DStruct.h
@@ -2,6 +2,7 @@
 
 #include <d3dx9.h>
 #include <d3dx9math.h>
+#include <stdint.h>
 #include <string>
 
 const float __PI = 3.141592654f;
@@ -1411,6 +1412,8 @@ void  _Convert2D_To_3DCoordinate(int ixScreen, int iyScreen, const __Matrix44 & 
                                  const D3DVIEWPORT9 & vp, __Vector3 & vPosResult, __Vector3 & vDirResult);
 float _Yaw2D(float fDirX, float fDirZ);
 void  _LoadStringFromResource(DWORD dwID, std::string & szText);
+std::string _FormatCoins(int64_t nCoins);
+void        _FormatCoins(int64_t nCoins, std::string & szCoins);
 
 inline D3DCOLOR _RGB_To_D3DCOLOR(COLORREF cr, DWORD dwAlpha) {
     D3DCOLOR cr2 = (dwAlpha << 24) | ((cr & 0x000000ff) << 16) | // R

--- a/src/game/GameBase.cpp
+++ b/src/game/GameBase.cpp
@@ -56,6 +56,23 @@ void _LoadStringFromResource(DWORD dwID, std::string & szText) {
     szText = szBuffer;
 }
 
+std::string _FormatCoins(int64_t nCoins) {
+    std::string szCoins;
+    ::_FormatCoins(nCoins, szCoins);
+    return szCoins;
+}
+
+void _FormatCoins(int64_t nCoins, std::string & szCoins) {
+    szCoins = std::to_string(nCoins);
+    for (int i = szCoins.length() - 1, iCount = 0; i >= 0; --i) {
+        if (iCount == 3) {
+            szCoins.insert(i + 1, ",");
+            iCount = 0;
+        }
+        ++iCount;
+    }
+}
+
 void CGameBase::StaticMemberInit() {
     //////////////////////////////////////////////////////////////////////////////////////////
     // Resource Table 로딩 및 초기화...

--- a/src/game/UIImageTooltipDlg.cpp
+++ b/src/game/UIImageTooltipDlg.cpp
@@ -157,8 +157,9 @@ void CUIImageTooltipDlg::SetPosSomething(int xpos, int ypos, int iNum) {
 }
 
 int CUIImageTooltipDlg::CalcTooltipStringNumAndWrite(__IconItemSkill * spItem, bool bPrice, bool bBuy) {
-    int         iIndex = 0;
-    std::string szStr;
+    int                iIndex = 0;
+    std::string        szStr;
+    static std::string szCoins;
 
     __InfoPlayerMySelf * pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
 
@@ -954,13 +955,14 @@ int CUIImageTooltipDlg::CalcTooltipStringNumAndWrite(__IconItemSkill * spItem, b
             if (bBuy) {
                 m_pStr[iIndex]->SetStyle(UI_STR_TYPE_HALIGN, UISTYLE_STRING_ALIGNLEFT);
                 ::_LoadStringFromResource(IDS_TOOLTIP_BUY_PRICE, szStr);
-                if (SetTooltipTextColor(pInfoExt->iGold,
-                                        spItem->pItemBasic->iPrice * spItem->pItemExt->siPriceMultiply)) {
+                int iBuyPrice = (spItem->pItemBasic->iPrice * spItem->pItemExt->siPriceMultiply);
+                if (SetTooltipTextColor(pInfoExt->iGold, iBuyPrice)) {
                     m_pStr[iIndex]->SetColor(m_CWhite);
                 } else {
                     m_pStr[iIndex]->SetColor(m_CRed);
                 }
-                sprintf(szBuff, szStr.c_str(), spItem->pItemBasic->iPrice * spItem->pItemExt->siPriceMultiply);
+                ::_FormatCoins(iBuyPrice, szCoins);
+                sprintf(szBuff, szStr.c_str(), szCoins.c_str());
                 m_pstdstr[iIndex] = szBuff;
             } else {
                 m_pStr[iIndex]->SetStyle(UI_STR_TYPE_HALIGN, UISTYLE_STRING_ALIGNLEFT);
@@ -970,7 +972,8 @@ int CUIImageTooltipDlg::CalcTooltipStringNumAndWrite(__IconItemSkill * spItem, b
                 if (iSellPrice < 1) {
                     iSellPrice = 1;
                 }
-                sprintf(szBuff, szStr.c_str(), iSellPrice);
+                ::_FormatCoins(iSellPrice, szCoins);
+                sprintf(szBuff, szStr.c_str(), szCoins.c_str());
                 m_pstdstr[iIndex] = szBuff;
             }
             iIndex++;


### PR DESCRIPTION
### Description

This PR implements formatting coins with commas for ui-tooltip. Note that this function can be possibly used for other scenarios, such as coins in player's inventory.

This also fixes a crash where the Texts.tbl format specifier expects a string, but was given an int. I reverted this commit, since the "fix" was wrong and the client was at fault: https://github.com/ko4life-net/ko-assets/commit/6181e4ac6be70c4c4afe31f6e216a9329f4466d7

Related to this PR: https://github.com/ko4life-net/ko-assets/pull/8

Also note that I put it near _LoadStringFromResource for now just for uniformity, as it may be used globally for other scenarios. We'll move them to some utility header file in the future once it's appriopriate in order to keep My_Struct3D.h more about 3D math.