### PR TITLE
Fix trade packet overflow using /trade cmd.

### DIFF
--- a/src/game/GameProcMain.cpp
+++ b/src/game/GameProcMain.cpp
@@ -5080,7 +5080,7 @@ void CGameProcMain::MsgSend_StateChange(e_SubPacket_State eSP, int iState) {
 }
 
 void CGameProcMain::MsgSend_PerTradeReq(int iDestID, bool bNear) {
-    BYTE byBuff[4];   // 패킷 버퍼..
+    BYTE byBuff[8]{}; // 패킷 버퍼..
     int  iOffset = 0; // 패킷 오프셋..
 
     CAPISocket::MP_AddByte(byBuff, iOffset, N3_PER_TRADE);


### PR DESCRIPTION
### Description

This PR fixes a crash when using the `/trade` command. The size of the buffer was too small to fill all the data, which caused the client to crash.