### PR TITLE
Cleanup code duplication in UIVarious.

### DIFF
--- a/src/game/StdAfx.h
+++ b/src/game/StdAfx.h
@@ -10,13 +10,15 @@
 #define VC_EXTRALEAN // Exclude rarely-used stuff from Windows headers
 #include <Windows.h>
 
-#include <string>
-#include <sstream>
-#include <vector>
-#include <list>
 #include <map>
 #include <set>
-#include <functional>
+#include <list>
+#include <vector>
+#include <format>
+#include <string>
+#include <sstream>
+#include <ranges>
+#include <algorithm>
 #include <filesystem>
 #include <io.h>
 
@@ -31,3 +33,10 @@ namespace fs = std::filesystem;
 #else
 #define TRACE(fmt, ...) (void)fmt
 #endif
+
+namespace N3 {
+static bool iequals(const std::string_view & lhs, const std::string_view & rhs) {
+    auto to_lower{std::ranges::views::transform(::tolower)};
+    return std::ranges::equal(lhs | to_lower, rhs | to_lower);
+}
+} // namespace N3

--- a/src/game/UIVarious.cpp
+++ b/src/game/UIVarious.cpp
@@ -259,9 +259,7 @@ void CUIState::UpdateHP(int iVal, int iValMax) {
         return;
     }
 
-    char szVal[64] = "0 / 0";
-    sprintf(szVal, "%d / %d", iVal, iValMax);
-    m_pText_HP->SetString(szVal);
+    m_pText_HP->SetString(std::format("{} / {}", iVal, iValMax));
 }
 
 void CUIState::UpdateMSP(int iVal, int iValMax) {
@@ -270,9 +268,7 @@ void CUIState::UpdateMSP(int iVal, int iValMax) {
         return;
     }
 
-    char szVal[64] = "0 / 0";
-    sprintf(szVal, "%d / %d", iVal, iValMax);
-    m_pText_MP->SetString(szVal);
+    m_pText_MP->SetString(std::format("{} / {}", iVal, iValMax));
 }
 
 void CUIState::UpdateExp(int iVal, int iValMax) {
@@ -281,43 +277,31 @@ void CUIState::UpdateExp(int iVal, int iValMax) {
         return;
     }
 
-    char szVal[64] = "0 / 0";
-    sprintf(szVal, "%d / %d", iVal, iValMax);
-    m_pText_Exp->SetString(szVal);
+    m_pText_Exp->SetString(std::format("{} / {}", iVal, iValMax));
+}
+
+void CUIState::UpdatePoints(CN3UIString * pText, int iVal, int iDelta) {
+    if (!pText) {
+        return;
+    }
+
+    if (iDelta != 0) {
+        if (iDelta > 0) {
+            pText->SetString(std::format("{}(+{})", iVal, iDelta));
+        } else {
+            pText->SetString(std::format("{}({})", iVal, iDelta));
+        }
+    } else {
+        pText->SetStringAsInt(iVal);
+    }
 }
 
 void CUIState::UpdateAttackPoint(int iVal, int iDelta) {
-    if (NULL == m_pText_AP) {
-        return;
-    }
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_AP->SetString(szBuff);
-    } else {
-        m_pText_AP->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_AP, iVal, iDelta);
 }
 
 void CUIState::UpdateGuardPoint(int iVal, int iDelta) {
-    if (NULL == m_pText_GP) {
-        return;
-    }
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_GP->SetString(szBuff);
-    } else {
-        m_pText_GP->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_GP, iVal, iDelta);
 }
 
 void CUIState::UpdateWeight(int iVal, int iValMax) {
@@ -325,218 +309,60 @@ void CUIState::UpdateWeight(int iVal, int iValMax) {
         return;
     }
 
-    char szVal[64] = "0 / 0";
-    sprintf(szVal, "%.1f/%.1f", (iVal * 0.1f), (iValMax * 0.1f));
-    m_pText_Weight->SetString(szVal);
+    std::string szWeight = std::format("{:.1f}/{:.1f}", (iVal * 0.1f), (iValMax * 0.1f));
+    m_pText_Weight->SetString(szWeight);
 
-    char        szBuf[64] = "";
     std::string szMsg;
     ::_LoadStringFromResource(IDS_INVEN_WEIGHT, szMsg);
-    std::string str = szMsg;
-    str += szVal;
 
     CUIInventory * pInv = CGameProcedure::s_pProcMain->m_pUIInventory;
     if (pInv) {
-        pInv->UpdateWeight(str);
+        pInv->UpdateWeight(szMsg + szWeight);
     }
 }
 
 void CUIState::UpdateStrength(int iVal, int iDelta) {
-    if (NULL == m_pText_Strength) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_Strength->SetString(szBuff);
-    } else {
-        m_pText_Strength->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_Strength, iVal, iDelta);
 }
 
 void CUIState::UpdateStamina(int iVal, int iDelta) {
-    if (NULL == m_pText_Stamina) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_Stamina->SetString(szBuff);
-    } else {
-        m_pText_Stamina->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_Stamina, iVal, iDelta);
 }
 
 void CUIState::UpdateDexterity(int iVal, int iDelta) {
-    if (NULL == m_pText_Dexterity) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_Dexterity->SetString(szBuff);
-    } else {
-        m_pText_Dexterity->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_Dexterity, iVal, iDelta);
 }
 
 void CUIState::UpdateIntelligence(int iVal, int iDelta) {
-    if (NULL == m_pText_Intelligence) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_Intelligence->SetString(szBuff);
-    } else {
-        m_pText_Intelligence->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_Intelligence, iVal, iDelta);
 }
 
 void CUIState::UpdateMagicAttak(int iVal, int iDelta) {
-    if (NULL == m_pText_MagicAttak) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_MagicAttak->SetString(szBuff);
-    } else {
-        m_pText_MagicAttak->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_MagicAttak, iVal, iDelta);
 }
 
 void CUIState::UpdateRegistFire(int iVal, int iDelta) {
-    if (NULL == m_pText_RegistFire) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_RegistFire->SetString(szBuff);
-    } else {
-        m_pText_RegistFire->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_RegistFire, iVal, iDelta);
 }
 
 void CUIState::UpdateRegistCold(int iVal, int iDelta) {
-    if (NULL == m_pText_RegistIce) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_RegistIce->SetString(szBuff);
-    } else {
-        m_pText_RegistIce->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_RegistIce, iVal, iDelta);
 }
 
 void CUIState::UpdateRegistLight(int iVal, int iDelta) {
-    if (NULL == m_pText_RegistLight) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_RegistLight->SetString(szBuff);
-    } else {
-        m_pText_RegistLight->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_RegistLight, iVal, iDelta);
 }
 
 void CUIState::UpdateRegistMagic(int iVal, int iDelta) {
-    if (NULL == m_pText_RegistMagic) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_RegistMagic->SetString(szBuff);
-    } else {
-        m_pText_RegistMagic->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_RegistMagic, iVal, iDelta);
 }
 
 void CUIState::UpdateRegistCurse(int iVal, int iDelta) {
-    if (NULL == m_pText_RegistCurse) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_RegistCurse->SetString(szBuff);
-    } else {
-        m_pText_RegistCurse->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_RegistCurse, iVal, iDelta);
 }
 
 void CUIState::UpdateRegistPoison(int iVal, int iDelta) {
-    if (NULL == m_pText_RegistPoison) {
-        return;
-    }
-
-    if (iDelta) {
-        char szBuff[64] = "";
-        if (iDelta > 0) {
-            sprintf(szBuff, "%d(+%d)", iVal, iDelta);
-        } else {
-            sprintf(szBuff, "%d(%d)", iVal, iDelta);
-        }
-        m_pText_RegistPoison->SetString(szBuff);
-    } else {
-        m_pText_RegistPoison->SetStringAsInt(iVal);
-    }
+    UpdatePoints(m_pText_RegistPoison, iVal, iDelta);
 }
 
 bool CUIState::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
@@ -668,12 +494,9 @@ bool CUIKnights::Load(HANDLE hFile) {
     //    if(m_pText_Grade)    m_pText_Grade->SetVisible(false);
     //    if(m_pText_Rank)    m_pText_Rank->SetVisible(false);
 
-    char szBuf[128];
     for (int i = 0; i < MAX_CLAN_GRADE; i++) {
-        sprintf(szBuf, "image_grade%.2d", i);
-        m_pImage_Grade[i] = (CN3UIImage *)(this->GetChildByID(szBuf));
+        m_pImage_Grade[i] = (CN3UIImage *)(this->GetChildByID(std::format("image_grade{:02d}", i)));
         __ASSERT(m_pImage_Grade[i], "NULL UI Component!!");
-        ;
         if (m_pImage_Grade[i]) {
             m_pImage_Grade[i]->SetVisible(false);
         }
@@ -692,9 +515,7 @@ bool CUIKnights::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
                 m_iPageCur = 1;
             }
 
-            char tmp[4];
-            sprintf(tmp, "%d", m_iPageCur);
-            m_pText_Page->SetString(tmp);
+            m_pText_Page->SetStringAsInt(m_iPageCur);
             RefreshPage();
             return true;
         }
@@ -705,9 +526,7 @@ bool CUIKnights::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
                 m_iPageCur = MaxPage;
             }
 
-            char tmp[4];
-            sprintf(tmp, "%d", m_iPageCur);
-            m_pText_Page->SetString(tmp);
+            m_pText_Page->SetStringAsInt(m_iPageCur);
             RefreshPage();
             return true;
         }
@@ -1054,9 +873,7 @@ bool CUIKnights::MsgRecv_MemberInfo(DataPack * pDataPack, int & iOffset) {
     int iPacketLen = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);
     int iKC = CAPISocket::Parse_GetShort(pDataPack->m_pData, iOffset);
 
-    char tmp[4];
-    sprintf(tmp, "%d", iKC);
-    m_pText_MemberCount->SetString(tmp);
+    m_pText_MemberCount->SetStringAsInt(iKC);
 
     int           iNameLength, iLevel;
     e_KnightsDuty eDuty = KNIGHTS_DUTY_UNKNOWN;
@@ -1079,8 +896,7 @@ bool CUIKnights::MsgRecv_MemberInfo(DataPack * pDataPack, int & iOffset) {
         this->MemberListAdd(szName, eDuty, eClass, iLevel, iConnected); // UI 에 추가..
     }
     m_iPageCur = 1;
-    sprintf(tmp, "%d", m_iPageCur);
-    m_pText_Page->SetString(tmp);
+    m_pText_Page->SetStringAsInt(m_iPageCur);
 
     this->MemberListUpdate(); // List 에 다 넣었으면 UI Update!!
 
@@ -1865,7 +1681,7 @@ void CUIVarious::UpdateAllStates(const __InfoPlayerBase * pInfoBase, const __Inf
         m_pPageState->m_pText_Nation->SetString(szVal);
     }
 
-    //    sprintf(szVal, "%d", pInfoExt->iRank);            m_pText_Rank->SetString(szVal);
+    // m_pText_Rank->SetStringAsInt(pInfoExt->iRank);
 
     m_pPageState->UpdateLevel(pInfoBase->iLevel);
     m_pPageState->UpdateExp(pInfoExt->iExp, pInfoExt->iExpNext);

--- a/src/game/UIVarious.h
+++ b/src/game/UIVarious.h
@@ -63,6 +63,7 @@ class CUIState : public CN3UIBase {
     void UpdateHP(int iVal, int iValMax);
     void UpdateMSP(int iVal, int iValMax);
     void UpdateExp(int iVal, int iValMax);
+    void UpdatePoints(CN3UIString * pText, int iVal, int iDelta);
     void UpdateAttackPoint(int iVal, int iDelta);
     void UpdateGuardPoint(int iVal, int iDelta);
     void UpdateWeight(int iVal, int iValMax);


### PR DESCRIPTION
### Description

This PR cleanup nonsense amount of code duplication in UIVarious.

Also encourage mode modern C++ to avoid vulnerable usages of sprintf by including the relevant headers in the precompiled header.

+ Cleanup sprintf usages and local buffer.
+ Use CN3UIString::SetStringAsInt instead of casting it in the caller.