### PR TITLE
Initial fix for coins / gold overflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Dependencies
         shell: cmd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [master]
     types: [opened, push, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   pr-checks:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: PR Checks
 on:
-  push: {}
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
     types: [opened, push, ready_for_review]
@@ -13,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check lint
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build
         shell: cmd

--- a/src/engine/N3Base/N3UIString.cpp
+++ b/src/engine/N3Base/N3UIString.cpp
@@ -469,6 +469,15 @@ void CN3UIString::ChangeFont(const std::string & szFont) {
 }
 #endif
 
+int64_t CN3UIString::GetStringAsInt(const std::vector<char> & remove /* = {}*/) {
+    std::string szTmp(m_szString);
+    for (char delim : remove) {
+        szTmp.erase(std::remove(szTmp.begin(), szTmp.end(), delim), szTmp.end());
+    }
+
+    return std::stoll(szTmp);
+}
+
 int CN3UIString::GetStringRealWidth(int iNum) {
     SIZE size{};
     BOOL bFlag = m_pDFont->GetTextExtent("°¡", lstrlen("°¡"), &size);

--- a/src/engine/N3Base/N3UIString.cpp
+++ b/src/engine/N3Base/N3UIString.cpp
@@ -78,9 +78,7 @@ void CN3UIString::SetString(const std::string & szString) {
 }
 
 void CN3UIString::SetStringAsInt(int iVal) {
-    char szBuff[32] = "";
-    sprintf(szBuff, "%d", iVal);
-    this->SetString(szBuff);
+    SetString(std::to_string(iVal));
 }
 
 void CN3UIString::SetString_NoWordWrap(const std::string & szString) {

--- a/src/engine/N3Base/N3UIString.h
+++ b/src/engine/N3Base/N3UIString.h
@@ -34,6 +34,7 @@ class CN3UIString : public CN3UIBase {
     void                SetColor(D3DCOLOR color) { m_Color = color; }
     D3DCOLOR            GetColor() const { return m_Color; }
     const std::string & GetString() { return m_szString; }
+    int64_t             GetStringAsInt(const std::vector<char> & remove = {});
     int                 GetLineCount() const { return m_iLineCount; }
     int                 GetStartLine() const { return m_iStartLine; }
     int                 GetStringRealWidth(int iNum);

--- a/src/game/APISocket.h
+++ b/src/game/APISocket.h
@@ -274,6 +274,10 @@ class CAPISocket {
         CopyMemory(dest + iOffset, &value, 4);
         iOffset += 4;
     }
+    static void MP_AddInt64(BYTE * dest, int & iOffset, __int64 nInt64) {
+        CopyMemory(dest + iOffset, &nInt64, 8);
+        iOffset += 8;
+    }
     static void MP_AddString(BYTE * dest, int & iOffset, const std::string & szString) {
         if (!szString.empty()) {
             CopyMemory(dest + iOffset, &(szString[0]), szString.size());

--- a/src/game/CountableItemEditDlg.cpp
+++ b/src/game/CountableItemEditDlg.cpp
@@ -203,16 +203,14 @@ void CCountableItemEditDlg::Close() {
     }
 }
 
-int CCountableItemEditDlg::GetQuantity() // "edit_trade" Edit Control 에서 정수값을 얻오온다..
-{
+int64_t CCountableItemEditDlg::GetQuantity() {
     CN3UIEdit * pEdit = (CN3UIEdit *)this->GetChildByID("edit_trade");
     __ASSERT(pEdit, "NULL UI Component!!");
 
-    return atoi(pEdit->GetString().c_str());
+    return std::stoll(pEdit->GetString());
 }
 
-void CCountableItemEditDlg::SetQuantity(int iQuantity) // "edit_trade" Edit Control 에서 정수값을 문자열로 세팅한다..
-{
+void CCountableItemEditDlg::SetQuantity(int64_t iQuantity) {
     CN3UIEdit * pEdit = (CN3UIEdit *)this->GetChildByID("edit_trade");
     __ASSERT(pEdit, "NULL UI Component!!");
 

--- a/src/game/CountableItemEditDlg.cpp
+++ b/src/game/CountableItemEditDlg.cpp
@@ -216,12 +216,11 @@ void CCountableItemEditDlg::SetQuantity(int iQuantity) // "edit_trade" Edit Cont
     CN3UIEdit * pEdit = (CN3UIEdit *)this->GetChildByID("edit_trade");
     __ASSERT(pEdit, "NULL UI Component!!");
 
-    char szBuff[64] = "";
-    if (iQuantity != -1) {
-        sprintf(szBuff, "%d", iQuantity);
+    if (iQuantity == -1) {
+        pEdit->SetString("");
+    } else {
+        pEdit->SetString(std::to_string(iQuantity));
     }
-
-    pEdit->SetString(szBuff);
 }
 
 //this_ui_add_start

--- a/src/game/CountableItemEditDlg.h
+++ b/src/game/CountableItemEditDlg.h
@@ -32,12 +32,12 @@ class CCountableItemEditDlg : public CN3UIBase {
     CN3UIButton * m_pBtnCancel;
 
   public:
-    bool OnKeyPress(int iKey);
-    bool Load(HANDLE hFile);
-    void SetVisibleWithNoSound(bool bVisible, bool bWork = false, bool bReFocus = false);
-    void SetVisible(bool bVisible);
-    int  GetQuantity();              // "edit_trade" Edit Control 에서 정수값을 얻오온다..
-    void SetQuantity(int iQuantity); // "edit_trade" Edit Control 에서 정수값을 문자열로 세팅한다..
+    bool    OnKeyPress(int iKey);
+    bool    Load(HANDLE hFile);
+    void    SetVisibleWithNoSound(bool bVisible, bool bWork = false, bool bReFocus = false);
+    void    SetVisible(bool bVisible);
+    int64_t GetQuantity();                  // "edit_trade" Edit Control 에서 정수값을 얻오온다..
+    void    SetQuantity(int64_t iQuantity); // "edit_trade" Edit Control 에서 정수값을 문자열로 세팅한다..
 
     CCountableItemEditDlg();
     virtual ~CCountableItemEditDlg();

--- a/src/game/GameBase.cpp
+++ b/src/game/GameBase.cpp
@@ -640,23 +640,20 @@ e_ItemType CGameBase::MakeResrcFileNameForUPC(__TABLE_ITEM_BASIC * pItem,       
         __ASSERT(0, "Invalid Item Position");
     }
 
-    char buffer[MAX_PATH]{};
     if (pszResrcFN) {
         if (pItem->dwIDResrc) {
-            sprintf(buffer, "Item\\%.1d_%.4d_%.2d_%.1d%s", (pItem->dwIDResrc / 10000000),
-                    (pItem->dwIDResrc / 1000) % 10000, (pItem->dwIDResrc / 10) % 100, pItem->dwIDResrc % 10,
-                    szExt.c_str());
-            *pszResrcFN = buffer;
-        } else // 아이콘만 있는 플러그나 파트 일수도 있다...
-        {
+            *pszResrcFN = std::format("Item\\{:d}_{:04d}_{:02d}_{:d}{}", (pItem->dwIDResrc / 10000000),
+                                      (pItem->dwIDResrc / 1000) % 10000, (pItem->dwIDResrc / 10) % 100,
+                                      pItem->dwIDResrc % 10, szExt);
+        } else {
+            // 아이콘만 있는 플러그나 파트 일수도 있다...
             *pszResrcFN = "";
         }
     }
     if (pszIconFN) {
-        //        sprintf(buffer,    "UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt", eType, iIndex, eRace, iPos);
-        sprintf(buffer, "UI\\ItemIcon_%.1d_%.4d_%.2d_%.1d.dxt", (pItem->dwIDIcon / 10000000),
-                (pItem->dwIDIcon / 1000) % 10000, (pItem->dwIDIcon / 10) % 100, pItem->dwIDIcon % 10);
-        *pszIconFN = buffer;
+        //*pszIconFN = std::format("UI\\ItemIcon_{:d}_{:04d}_{:02d}_{:d}.dxt", eType, iIndex, eRace, iPos);
+        *pszIconFN = std::format("UI\\ItemIcon_{:d}_{:04d}_{:02d}_{:d}.dxt", (pItem->dwIDIcon / 10000000),
+                                 (pItem->dwIDIcon / 1000) % 10000, (pItem->dwIDIcon / 10) % 100, pItem->dwIDIcon % 10);
     }
 
     return eType;

--- a/src/game/GameCursor.cpp
+++ b/src/game/GameCursor.cpp
@@ -39,11 +39,8 @@ bool CGameCursor::Load(HANDLE hFile) {
     m_hCursor = ::GetCursor();
     ::SetCursor(NULL);
 
-    char szBuf[128];
     for (int i = 0; i < CURSOR_COUNT; i++) {
-        sprintf(szBuf, "Image_Cursor%.2d", i);
-
-        m_pImageCursor[i] = (CN3UIImage *)(this->GetChildByID(szBuf));
+        m_pImageCursor[i] = (CN3UIImage *)(this->GetChildByID(std::format("Image_Cursor{:02d}", i)));
         __ASSERT(m_pImageCursor[i], "NULL UI Component!!!");
     }
     return true;

--- a/src/game/GameDef.h
+++ b/src/game/GameDef.h
@@ -565,7 +565,7 @@ struct __InfoPlayerMySelf : public __InfoPlayerOther {
     int iMSP;
 
     int           iTargetHPPercent;
-    int           iGold;
+    int64_t       iGold;
     int           iExpNext;
     int           iExp;
     int           iRealmPoint;         // 국가 기여도

--- a/src/game/ItemRepairMgr.cpp
+++ b/src/game/ItemRepairMgr.cpp
@@ -196,16 +196,12 @@ void CItemRepairMgr::ReceiveResultFromServer(int iResult, int iUserGold) {
 }
 
 void CItemRepairMgr::UpdateUserTotalGold(int iGold) {
-    char          szGold[32];
-    CN3UIString * pStatic = NULL;
-
     // µ· ¾÷µ¥ÀÌÆ®..
     s_pPlayer->m_InfoExt.iGold = iGold;
-    sprintf(szGold, "%d", iGold);
-    pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
+    CN3UIString * pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pStatic, "NULL UI Component!!");
     if (pStatic) {
-        pStatic->SetString(szGold);
+        pStatic->SetString(::_FormatCoins(iGold));
     }
 }
 

--- a/src/game/ItemRepairMgr.cpp
+++ b/src/game/ItemRepairMgr.cpp
@@ -150,7 +150,7 @@ void CItemRepairMgr::Tick() {
     }
 }
 
-void CItemRepairMgr::ReceiveResultFromServer(int iResult, int iUserGold) {
+void CItemRepairMgr::ReceiveResultFromServer(int iResult, int64_t iUserGold) {
     CUIRepairTooltipDlg * pDlg = CGameProcedure::s_pProcMain->m_pUIRepairTooltip;
     CUIInventory *        pInv = CGameProcedure::s_pProcMain->m_pUIInventory;
     if (!pInv) {
@@ -195,7 +195,7 @@ void CItemRepairMgr::ReceiveResultFromServer(int iResult, int iUserGold) {
     CGameProcedure::SetGameCursor(CGameProcedure::s_hCursorPreRepair, true);
 }
 
-void CItemRepairMgr::UpdateUserTotalGold(int iGold) {
+void CItemRepairMgr::UpdateUserTotalGold(int64_t iGold) {
     // µ· ¾÷µ¥ÀÌÆ®..
     s_pPlayer->m_InfoExt.iGold = iGold;
     CN3UIString * pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");

--- a/src/game/ItemRepairMgr.h
+++ b/src/game/ItemRepairMgr.h
@@ -16,8 +16,8 @@ class CItemRepairMgr : CGameBase {
     virtual ~CItemRepairMgr();
 
     void Tick();
-    void ReceiveResultFromServer(int iResult, int iUserGold);
+    void ReceiveResultFromServer(int iResult, int64_t iUserGold);
 
-    void UpdateUserTotalGold(int iGold);
+    void UpdateUserTotalGold(int64_t iGold);
     int  CalcRepairGold(struct __IconItemSkill * spItem);
 };

--- a/src/game/N3UIWndBase.cpp
+++ b/src/game/N3UIWndBase.cpp
@@ -64,13 +64,11 @@ void CN3UIWndBase::InitIconWnd(e_UIWND eWnd) {
 }
 
 CN3UIArea * CN3UIWndBase::GetChildAreaByiOrder(eUI_AREA_TYPE eUAT, int iOrder) {
-    char pszID[32];
-    sprintf(pszID, "%d", iOrder);
-
+    std::string szID(std::to_string(iOrder));
     for (UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor) {
         CN3UIArea * pChild = (CN3UIArea *)(*itor);
         if ((pChild->UIType() == UI_TYPE_AREA) && (pChild->m_eAreaType == eUAT)) {
-            if (pChild->m_szID == pszID) {
+            if (pChild->m_szID == szID) {
                 return pChild;
             }
         }
@@ -80,13 +78,11 @@ CN3UIArea * CN3UIWndBase::GetChildAreaByiOrder(eUI_AREA_TYPE eUAT, int iOrder) {
 }
 
 CN3UIString * CN3UIWndBase::GetChildStringByiOrder(int iOrder) {
-    char pszID[32];
-    sprintf(pszID, "%d", iOrder);
-
+    std::string szID(std::to_string(iOrder));
     for (UIListItor itor = m_Children.begin(); m_Children.end() != itor; ++itor) {
         CN3UIString * pChild = (CN3UIString *)(*itor);
         if (pChild->UIType() == UI_TYPE_STRING) {
-            if (pChild->m_szID == pszID) {
+            if (pChild->m_szID == szID) {
                 return pChild;
             }
         }

--- a/src/game/SubProcPerTrade.cpp
+++ b/src/game/SubProcPerTrade.cpp
@@ -278,8 +278,8 @@ void CSubProcPerTrade::PerTradeCompleteSuccess() // 개인 거래 최종 성공..
 
 void CSubProcPerTrade::PerTradeCompleteCancel() // 개인 거래 취소..
 {
-    int iGold,    // 거래창의 값..
-        iMyMoney; // 인벤토리의 값..
+    int64_t iGold;    // 거래창의 값..
+    int64_t iMyMoney; // 인벤토리의 값..
 
     if ((int)m_ePerTradeState >= (int)PER_TRADE_STATE_NORMAL) {
         // 먼저 돈을 검사 한다..
@@ -507,9 +507,9 @@ void CSubProcPerTrade::RequestItemCountEdit() {
 
 void CSubProcPerTrade::ItemCountEditOK() {
     std::string szGold;
-    int         iGold, // 거래창의 값..
-        iGoldOffset,   // 편집창의 값..
-        iMyMoney;      // 인벤토리의 값..
+    int64_t     iGold;       // 거래창의 값..
+    int64_t     iGoldOffset; // 편집창의 값..
+    int64_t     iMyMoney;    // 인벤토리의 값..
 
     // 거래 창의 내 현재 돈을 얻어 온다..
     CN3UIString * pStrMy = (CN3UIString *)m_pUIPerTradeDlg->GetChildByID("string_money_my");
@@ -561,7 +561,7 @@ void CSubProcPerTrade::ItemCountEditOK() {
     CAPISocket::MP_AddByte(byBuff, iOffset, N3_SP_PER_TRADE_ADD);
     CAPISocket::MP_AddByte(byBuff, iOffset, 0xff);
     CAPISocket::MP_AddDword(byBuff, iOffset, dwGold);
-    CAPISocket::MP_AddDword(byBuff, iOffset, iGoldOffset);
+    CAPISocket::MP_AddInt64(byBuff, iOffset, iGoldOffset);
 
     CGameProcedure::s_pSocket->Send(byBuff, iOffset); // 보냄..
 
@@ -649,8 +649,8 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(BYTE bResult) {
     CN3UIWndBase::m_sRecoveryJobInfo.m_bWaitFromServer = false;
 
     std::string szGold;
-    int         iGold, // 거래창의 값..
-        iMyMoney;      // 인벤토리의 값..
+    int64_t     iGold;    // 거래창의 값..
+    int64_t     iMyMoney; // 인벤토리의 값..
 
     switch (bResult) {
     case 0x01:
@@ -802,7 +802,8 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(BYTE bResult) {
 }
 
 void CSubProcPerTrade::ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int iDurability) {
-    int iGold, iDestiOrder; // 거래창의 값..
+    int64_t iGold;
+    int     iDestiOrder; // 거래창의 값..
 
     if (iItemID == dwGold) {
         // 거래 창의 다른 사람의 현재 돈을 얻어 온다..
@@ -953,7 +954,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeOtherDecide() {
     PerTradeOtherDecision();
 }
 
-void CSubProcPerTrade::ReceiveMsgPerTradeDoneSuccessBegin(int iTotalGold) {
+void CSubProcPerTrade::ReceiveMsgPerTradeDoneSuccessBegin(int64_t iTotalGold) {
     CN3UIString * pString = NULL;
     pString = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pString, "NULL UI Component!!");

--- a/src/game/SubProcPerTrade.cpp
+++ b/src/game/SubProcPerTrade.cpp
@@ -278,17 +278,15 @@ void CSubProcPerTrade::PerTradeCompleteSuccess() // 개인 거래 최종 성공..
 
 void CSubProcPerTrade::PerTradeCompleteCancel() // 개인 거래 취소..
 {
-    std::string str;
-    int         iGold, // 거래창의 값..
-        iMyMoney;      // 인벤토리의 값..
+    int iGold,    // 거래창의 값..
+        iMyMoney; // 인벤토리의 값..
 
     if ((int)m_ePerTradeState >= (int)PER_TRADE_STATE_NORMAL) {
         // 먼저 돈을 검사 한다..
         // 거래 창의 내 현재 돈을 얻어 온다..
         CN3UIString * pStrMy = (CN3UIString *)m_pUIPerTradeDlg->GetChildByID("string_money_my");
         __ASSERT(pStrMy, "NULL UI Component!!");
-        str = pStrMy->GetString();
-        iGold = atoi(str.c_str());
+        iGold = pStrMy->GetStringAsInt({','});
 
         // 현재 내가 가진 돈을 얻어 온다..
         iMyMoney = s_pPlayer->m_InfoExt.iGold;
@@ -508,8 +506,7 @@ void CSubProcPerTrade::RequestItemCountEdit() {
 }
 
 void CSubProcPerTrade::ItemCountEditOK() {
-    char        szGold[32];
-    std::string str;
+    std::string szGold;
     int         iGold, // 거래창의 값..
         iGoldOffset,   // 편집창의 값..
         iMyMoney;      // 인벤토리의 값..
@@ -517,8 +514,7 @@ void CSubProcPerTrade::ItemCountEditOK() {
     // 거래 창의 내 현재 돈을 얻어 온다..
     CN3UIString * pStrMy = (CN3UIString *)m_pUIPerTradeDlg->GetChildByID("string_money_my");
     __ASSERT(pStrMy, "NULL UI Component!!");
-    str = pStrMy->GetString();
-    iGold = atoi(str.c_str());
+    iGold = pStrMy->GetStringAsInt({','});
 
     //  입력 창의 값을 얻어서
     iGoldOffset = m_pUITradeEditDlg->GetQuantity();
@@ -541,7 +537,7 @@ void CSubProcPerTrade::ItemCountEditOK() {
     s_pPlayer->m_InfoExt.iGold = iMyMoney;
 
     // 돈 표시.. 인벤토리..
-    sprintf(szGold, "%d", iMyMoney);
+    szGold = ::_FormatCoins(iMyMoney);
     CN3UIString * pString = NULL;
     pString = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pString, "NULL UI Component!!");
@@ -554,8 +550,7 @@ void CSubProcPerTrade::ItemCountEditOK() {
 
     // 돈 표시.. 개인 거래 창..
     iGold += iGoldOffset;
-    sprintf(szGold, "%d", iGold);
-    pStrMy->SetString(szGold);
+    pStrMy->SetString(::_FormatCoins(iGold));
 
     // 서버에게 전송한다..
     BYTE byBuff[16];  // 패킷 버퍼..
@@ -595,10 +590,6 @@ void CSubProcPerTrade::ItemCountEditCancel() {
 
 void CSubProcPerTrade::PerTradeMyDecision() // 내가 거래를 결정 했다..
 {
-    std::string   szFN = "btn_trade_my";
-    CN3UIButton * pButton;
-    pButton = (CN3UIButton *)m_pUIPerTradeDlg->GetChildButtonByName(szFN);
-
     // 서버에게 전송한다..
     BYTE byBuff[4];   // 패킷 버퍼..
     int  iOffset = 0; // 패킷 오프셋..
@@ -610,6 +601,7 @@ void CSubProcPerTrade::PerTradeMyDecision() // 내가 거래를 결정 했다..
     CGameProcedure::s_pSocket->Send(byBuff, iOffset); // 보냄..
 
     // 내 결정 버튼 Disable..
+    CN3UIButton * pButton = (CN3UIButton *)m_pUIPerTradeDlg->GetChildButtonByName("btn_trade_my");
     if (pButton) {
         pButton->SetState(UI_STATE_BUTTON_DISABLE);
     }
@@ -656,8 +648,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(BYTE bResult) {
     // 상태를 변화시키고.. 창을 닫고..
     CN3UIWndBase::m_sRecoveryJobInfo.m_bWaitFromServer = false;
 
-    char        szGold[32];
-    std::string str;
+    std::string szGold;
     int         iGold, // 거래창의 값..
         iMyMoney;      // 인벤토리의 값..
 
@@ -672,8 +663,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(BYTE bResult) {
             // 거래 창의 내 현재 돈을 얻어 온다..
             CN3UIString * pStrMy = (CN3UIString *)m_pUIPerTradeDlg->GetChildByID("string_money_my");
             __ASSERT(pStrMy, "NULL UI Component!!");
-            str = pStrMy->GetString();
-            iGold = atoi(str.c_str());
+            iGold = pStrMy->GetStringAsInt({','});
 
             // 현재 내가 가진 돈을 얻어 온다..
             iMyMoney = s_pPlayer->m_InfoExt.iGold;
@@ -682,7 +672,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(BYTE bResult) {
             s_pPlayer->m_InfoExt.iGold = iMyMoney;
 
             // 돈 표시.. 인벤토리..
-            sprintf(szGold, "%d", iMyMoney);
+            szGold = ::_FormatCoins(iMyMoney);
             CN3UIString * pString = NULL;
             pString = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
             __ASSERT(pString, "NULL UI Component!!");
@@ -695,8 +685,7 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(BYTE bResult) {
 
             // 돈 표시.. 개인 거래 창..
             iGold -= m_iGoldOffsetBackup;
-            sprintf(szGold, "%d", iGold);
-            pStrMy->SetString(szGold);
+            pStrMy->SetString(::_FormatCoins(iGold));
         } break;
 
         case PER_TRADE_ITEM_OTHER: {
@@ -813,23 +802,19 @@ void CSubProcPerTrade::ReceiveMsgPerTradeAdd(BYTE bResult) {
 }
 
 void CSubProcPerTrade::ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int iDurability) {
-    char        szGold[32];
-    std::string str;
-    int         iGold, iDestiOrder; // 거래창의 값..
+    int iGold, iDestiOrder; // 거래창의 값..
 
     if (iItemID == dwGold) {
         // 거래 창의 다른 사람의 현재 돈을 얻어 온다..
         CN3UIString * pStrOther = (CN3UIString *)m_pUIPerTradeDlg->GetChildByID("string_money_other");
         __ASSERT(pStrOther, "NULL UI Component!!");
-        str = pStrOther->GetString();
-        iGold = atoi(str.c_str());
+        iGold = pStrOther->GetStringAsInt({','});
 
         // 돈을 더한 다음..
         iGold += iCount;
 
         // 돈 표시.. 개인 거래 창..
-        sprintf(szGold, "%d", iGold);
-        pStrOther->SetString(szGold);
+        pStrOther->SetString(::_FormatCoins(iGold));
     } else {
         // 아이템이 들어갈 수 있는지 확인, 아이템이 들어 가는 자리 계산..
         bool bFound = false;
@@ -969,14 +954,10 @@ void CSubProcPerTrade::ReceiveMsgPerTradeOtherDecide() {
 }
 
 void CSubProcPerTrade::ReceiveMsgPerTradeDoneSuccessBegin(int iTotalGold) {
-    char szGold[32];
-    sprintf(szGold, "%d", iTotalGold);
-
     CN3UIString * pString = NULL;
     pString = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pString, "NULL UI Component!!");
-    pString->SetString(szGold);
-
+    pString->SetString(::_FormatCoins(iTotalGold));
     s_pPlayer->m_InfoExt.iGold = iTotalGold;
 }
 
@@ -1088,14 +1069,11 @@ void CSubProcPerTrade::ReceiveMsgPerTradeDoneSuccessEnd() {
 }
 
 void CSubProcPerTrade::ReceiveMsgPerTradeDoneFail() {
-    char        szBuf[256] = "";
-    std::string szMsg;
-
     // 메시지 박스 텍스트 표시..
     if (s_pOPMgr->UPCGetByID(m_iOtherID, false) != NULL) {
+        std::string szMsg;
         ::_LoadStringFromResource(IDS_PER_TRADE_FAIL, szMsg);
-        sprintf(szBuf, szMsg.c_str());
-        CGameProcedure::s_pProcMain->MsgOutput(szBuf, 0xffffffff);
+        CGameProcedure::s_pProcMain->MsgOutput(szMsg, 0xffffffff);
 
         // 메시지 박스 텍스트 표시..
         ::_LoadStringFromResource(IDS_ITEM_TOOMANY_OR_HEAVY, szMsg);
@@ -1108,13 +1086,12 @@ void CSubProcPerTrade::ReceiveMsgPerTradeDoneFail() {
 }
 
 void CSubProcPerTrade::ReceiveMsgPerTradeCancel() {
-    char        szBuf[256] = "";
-    std::string szMsg;
-
     // 메시지 박스 텍스트 표시..
     if (s_pOPMgr->UPCGetByID(m_iOtherID, false) != NULL) {
-        ::_LoadStringFromResource(IDS_OTHER_PER_TRADE_CANCEL, szMsg);
-        sprintf(szBuf, szMsg.c_str(), (s_pOPMgr->UPCGetByID(m_iOtherID, false))->IDString().c_str());
+        std::string szFmt;
+        ::_LoadStringFromResource(IDS_OTHER_PER_TRADE_CANCEL, szFmt);
+        char szBuf[256]{};
+        sprintf(szBuf, szFmt.c_str(), (s_pOPMgr->UPCGetByID(m_iOtherID, false))->IDString().c_str());
         CGameProcedure::s_pProcMain->MsgOutput(szBuf, 0xffff3b3b);
     }
 

--- a/src/game/SubProcPerTrade.h
+++ b/src/game/SubProcPerTrade.h
@@ -89,7 +89,7 @@ class CSubProcPerTrade : public CGameBase {
     void ReceiveMsgPerTradeAdd(BYTE bResult);
     void ReceiveMsgPerTradeOtherAdd(int iItemID, int iCount, int iDurability);
     void ReceiveMsgPerTradeOtherDecide();
-    void ReceiveMsgPerTradeDoneSuccessBegin(int iTotalGold);
+    void ReceiveMsgPerTradeDoneSuccessBegin(int64_t iTotalGold);
     void ReceiveMsgPerTradeDoneItemMove(BYTE bItemPos, int iItemID, int iCount, int iDurability);
     void ReceiveMsgPerTradeDoneSuccessEnd();
     void ReceiveMsgPerTradeDoneFail();

--- a/src/game/UIDroppedItemDlg.cpp
+++ b/src/game/UIDroppedItemDlg.cpp
@@ -453,7 +453,7 @@ bool CUIDroppedItemDlg::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
     return true;
 }
 
-void CUIDroppedItemDlg::GetItemByIDToInventory(BYTE bResult, int iItemID, int iGold, int iPos, int iItemCount,
+void CUIDroppedItemDlg::GetItemByIDToInventory(BYTE bResult, int iItemID, int64_t iGold, int iPos, int iItemCount,
                                                int iStrLen, std::string strString) {
     // 아이템 리스트에서 아이템을 찾고..
     bool                 bFound = false;

--- a/src/game/UIDroppedItemDlg.cpp
+++ b/src/game/UIDroppedItemDlg.cpp
@@ -503,7 +503,7 @@ void CUIDroppedItemDlg::GetItemByIDToInventory(BYTE bResult, int iItemID, int iG
         pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
         __ASSERT(pStatic, "NULL UI Component!!");
         if (pStatic) {
-            pStatic->SetStringAsInt(iGold);
+            pStatic->SetString(::_FormatCoins(iGold));
         }
 
         if (!IsVisible()) {
@@ -785,7 +785,7 @@ void CUIDroppedItemDlg::GetItemByIDToInventory(BYTE bResult, int iItemID, int iG
             pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
             __ASSERT(pStatic, "NULL UI Component!!");
             if (pStatic) {
-                pStatic->SetStringAsInt(iGold);
+                pStatic->SetString(::_FormatCoins(iGold));
             }
 
             spItem = CN3UIWndBase::m_sRecoveryJobInfo.pItemSource;

--- a/src/game/UIDroppedItemDlg.h
+++ b/src/game/UIDroppedItemDlg.h
@@ -35,10 +35,10 @@ class CUIDroppedItemDlg : public CN3UIWndBase {
     void          Render();
     void          EnterDroppedState(int xpos, int ypos);
     void          LeaveDroppedState();
-    void          GetItemByIDToInventory(BYTE bResult, int iItemId, int iGold, int iPos, int iItemCount, int iStrLen,
-                                         std::string strString);
-    void          AddToItemTable(int iItemId, int iItemCount, int iOrder);
-    void          AddToItemTableToInventory(int iItemId, int iItemCount, int iOrder);
+    void GetItemByIDToInventory(BYTE bResult, int iItemId, int64_t iGold, int iPos, int iItemCount, int iStrLen,
+                                std::string strString);
+    void AddToItemTable(int iItemId, int iItemCount, int iOrder);
+    void AddToItemTableToInventory(int iItemId, int iItemCount, int iOrder);
 
     bool ReceiveIconDrop(__IconItemSkill * spItem, POINT ptCur);
 

--- a/src/game/UIHotKeyDlg.cpp
+++ b/src/game/UIHotKeyDlg.cpp
@@ -351,16 +351,12 @@ void CUIHotKeyDlg::InitIconUpdate() {
         return;
     }
 
-    char        szSkill[32];
     int         iSkillCount = 0;
     CHotkeyData HD;
-    //    DWORD bitMask;
+    // DWORD bitMask;
 
     while (iHCount--) {
-        std::string str = "Data";
-        sprintf(szSkill, "%d", iSkillCount);
-        str += szSkill;
-        if (CGameProcedure::RegGetSetting(str.c_str(), &HD, sizeof(CHotkeyData))) {
+        if (CGameProcedure::RegGetSetting(std::to_string(iSkillCount).c_str(), &HD, sizeof(CHotkeyData))) {
             __TABLE_UPC_SKILL * pUSkill = NULL;
 
             // Skill Tree Window가 아이디를 갖고 있지 않으면 continue..
@@ -378,9 +374,7 @@ void CUIHotKeyDlg::InitIconUpdate() {
             spSkill->pSkill = pUSkill;
 
             // 아이콘 이름 만들기.. ^^
-            char buffer[MAX_PATH]{};
-            sprintf(buffer, "UI\\skillicon_%.2d_%d.dxt", HD.iID % 100, HD.iID / 100);
-            spSkill->szIconFN = buffer;
+            spSkill->szIconFN = std::format("UI\\skillicon_{:02d}_{:d}.dxt", HD.iID % 100, HD.iID / 100);
 
             // 아이콘 로드하기.. ^^
             spSkill->pUIIcon = new CN3UIIcon;
@@ -434,18 +428,13 @@ void CUIHotKeyDlg::CloseIconRegistry() {
 
     CGameProcedure::RegPutSetting("Count", &iHCount, sizeof(int));
 
-    char szSkill[32];
-    int  iSkillCount = 0;
+    int iSkillCount = 0;
 
     for (int i = 0; i < MAX_SKILL_HOTKEY_PAGE; i++) {
         for (int j = 0; j < MAX_SKILL_IN_HOTKEY; j++) {
             if (m_pMyHotkey[i][j] != NULL) {
-                std::string str = "Data";
-                sprintf(szSkill, "%d", iSkillCount);
-                str += szSkill;
-
                 CHotkeyData HD(i, j, m_pMyHotkey[i][j]->pSkill->dwID);
-                CGameProcedure::RegPutSetting(str.c_str(), &HD, sizeof(CHotkeyData));
+                CGameProcedure::RegPutSetting(std::to_string(iSkillCount).c_str(), &HD, sizeof(CHotkeyData));
                 iSkillCount++;
             }
         }
@@ -689,37 +678,24 @@ void CUIHotKeyDlg::ClassChangeHotkeyFlush() {
 }
 
 CN3UIString * CUIHotKeyDlg::GetTooltipStrControl(int iIndex) {
-    CN3UIString * pStr = NULL;
-    std::string   str = "";
-    char          cstr[4];
-    sprintf(cstr, "%d", iIndex + 10);
-    str += cstr;
-    pStr = (CN3UIString *)GetChildByID(str);
+    CN3UIString * pStr = (CN3UIString *)GetChildByID(std::to_string(iIndex + 10));
     __ASSERT(pStr, "NULL UI Component!!");
     return pStr;
 }
 
 CN3UIString * CUIHotKeyDlg::GetCountStrControl(int iIndex) {
-    CN3UIString * pStr = NULL;
-    std::string   str = "";
-    char          cstr[4];
-    sprintf(cstr, "%d", iIndex);
-    str += cstr;
-    pStr = (CN3UIString *)GetChildByID(str);
+    CN3UIString * pStr = (CN3UIString *)GetChildByID(std::to_string(iIndex));
     __ASSERT(pStr, "NULL UI Component!!");
     return pStr;
 }
 
 void CUIHotKeyDlg::DisplayTooltipStr(__IconItemSkill * spSkill) {
-    char pszDesc[256];
-
     int iIndex = GetTooltipCurPageIndex(spSkill);
     if (iIndex != -1) {
         if (!m_pTooltipStr[iIndex]->IsVisible()) {
             m_pTooltipStr[iIndex]->SetVisible(true);
         }
-        sprintf(pszDesc, "%s", spSkill->pSkill->szName.c_str());
-        m_pTooltipStr[iIndex]->SetString(pszDesc);
+        m_pTooltipStr[iIndex]->SetString(spSkill->pSkill->szName);
         m_pTooltipStr[iIndex]->Render();
     }
 }
@@ -733,16 +709,14 @@ void CUIHotKeyDlg::DisableTooltipDisplay() {
 }
 
 void CUIHotKeyDlg::DisplayCountStr(__IconItemSkill * spSkill) {
-    char pszDesc[256];
-
     int iIndex = GetCountCurPageIndex(spSkill);
     if (iIndex != -1) {
         if (!m_pCountStr[iIndex]->IsVisible()) {
             m_pCountStr[iIndex]->SetVisible(true);
         }
-        sprintf(pszDesc, "%d",
-                CGameProcedure::s_pProcMain->m_pUIInventory->GetCountInInvByID(spSkill->pSkill->dwExhaustItem));
-        m_pCountStr[iIndex]->SetString(pszDesc);
+
+        int iCount = CGameProcedure::s_pProcMain->m_pUIInventory->GetCountInInvByID(spSkill->pSkill->dwExhaustItem);
+        m_pCountStr[iIndex]->SetStringAsInt(iCount);
         m_pCountStr[iIndex]->Render();
     }
 }
@@ -827,10 +801,8 @@ bool CUIHotKeyDlg::ReceiveIconDrop(__IconItemSkill * spItem, POINT ptCur) {
         spSkill->pSkill = pUSkill;
 
         // 아이콘 이름 만들기.. ^^
-        char buffer[MAX_PATH]{};
-        sprintf(buffer, "UI\\skillicon_%.2d_%d.dxt", spItem->pItemBasic->dwEffectID1 % 100,
-                spItem->pItemBasic->dwEffectID1 / 100);
-        spSkill->szIconFN = buffer;
+        spSkill->szIconFN = std::format("UI\\skillicon_{:02d}_{:d}.dxt", spItem->pItemBasic->dwEffectID1 % 100,
+                                        spItem->pItemBasic->dwEffectID1 / 100);
 
         // 아이콘 로드하기.. ^^
         spSkill->pUIIcon = new CN3UIIcon;

--- a/src/game/UIImageTooltipDlg.cpp
+++ b/src/game/UIImageTooltipDlg.cpp
@@ -35,14 +35,8 @@ void CUIImageTooltipDlg::Release() {
 }
 
 void CUIImageTooltipDlg::InitPos() {
-    std::string str;
-    char        cstr[4];
-
     for (int i = 0; i < MAX_TOOLTIP_COUNT; i++) {
-        str = "string_";
-        sprintf(cstr, "%d", i);
-        str += cstr;
-        m_pStr[i] = (CN3UIString *)GetChildByID(str);
+        m_pStr[i] = (CN3UIString *)GetChildByID(std::format("string_{}", i));
         __ASSERT(m_pStr[i], "NULL UI Component!!");
     }
 

--- a/src/game/UIInventory.cpp
+++ b/src/game/UIInventory.cpp
@@ -2310,7 +2310,7 @@ void CUIInventory::DurabilityChange(e_ItemSlot eSlot, int iDurability) {
     }
 }
 
-void CUIInventory::ReceiveResultFromServer(int iResult, int iUserGold) {
+void CUIInventory::ReceiveResultFromServer(int iResult, int64_t iUserGold) {
     m_cItemRepairMgr.ReceiveResultFromServer(iResult, iUserGold);
 }
 

--- a/src/game/UIInventory.cpp
+++ b/src/game/UIInventory.cpp
@@ -163,7 +163,7 @@ void CUIInventory::Open(e_InvenState eIS) {
     CN3UIString * pStatic = (CN3UIString *)GetChildByID("text_gold");
     __ASSERT(pStatic, "NULL UI Component!!");
     if (pStatic) {
-        pStatic->SetStringAsInt(CGameBase::s_pPlayer->m_InfoExt.iGold);
+        pStatic->SetString(::_FormatCoins(CGameBase::s_pPlayer->m_InfoExt.iGold));
     }
 
     // 스르륵 열린다!!
@@ -180,7 +180,7 @@ void CUIInventory::GoldUpdate() {
     CN3UIString * pStatic = (CN3UIString *)GetChildByID("text_gold");
     __ASSERT(pStatic, "NULL UI Component!!");
     if (pStatic) {
-        pStatic->SetStringAsInt(CGameBase::s_pPlayer->m_InfoExt.iGold);
+        pStatic->SetString(::_FormatCoins(CGameBase::s_pPlayer->m_InfoExt.iGold));
     }
 }
 

--- a/src/game/UIInventory.h
+++ b/src/game/UIInventory.h
@@ -138,7 +138,7 @@ class CUIInventory : public CN3UIWndBase {
     void         DurabilityChange(e_ItemSlot eSlot, int iDurability);
     e_InvenState GetInvState() { return m_eInvenState; }
 
-    void ReceiveResultFromServer(int iResult, int iUserGold);
+    void ReceiveResultFromServer(int iResult, int64_t iUserGold);
 
     int GetCountInInvByID(int iID);
 

--- a/src/game/UIItemExchange.cpp
+++ b/src/game/UIItemExchange.cpp
@@ -269,7 +269,7 @@ void CUIItemExchange::UpdateGoldValue() {
     }
 }
 
-void CUIItemExchange::UpdateUserTotalGold(int iGold) {
+void CUIItemExchange::UpdateUserTotalGold(int64_t iGold) {
     // 돈 업데이트..
     CGameBase::s_pPlayer->m_InfoExt.iGold = iGold;
     CN3UIString * pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
@@ -444,7 +444,7 @@ void CUIItemExchange::UserPressOK() {
     CN3UIWndBase::m_sRecoveryJobInfo.m_bWaitFromServer = true;
 }
 
-void CUIItemExchange::ReceiveResultFromServer(int iResult, int iUserGold) {
+void CUIItemExchange::ReceiveResultFromServer(int iResult, int64_t iUserGold) {
     // 성공이면 npc영역의 Durability를 최대값으로..
     if (iResult == 0x01) {
         for (int i = 0; i < MAX_ITEM_EX_RE_NPC; i++) {

--- a/src/game/UIItemExchange.cpp
+++ b/src/game/UIItemExchange.cpp
@@ -36,7 +36,7 @@ CUIItemExchange::CUIItemExchange() {
         m_pMyNpcWndOriginIndex[i] = -1;
     }
 
-    m_pTotalPrice = 0;
+    m_iTotalPrice = 0;
 }
 
 CUIItemExchange::~CUIItemExchange() {
@@ -251,7 +251,7 @@ bool CUIItemExchange::ReceiveIconDrop(__IconItemSkill * spItem, POINT ptCur) {
     m_pMyNpcWndOriginIndex[i] = CN3UIWndBase::m_sSelectedIconInfo.UIWndSelect.iOrder;
 
     // 수리비용 업그레이드..
-    m_pTotalPrice += CalcRepairGold(spItem);
+    m_iTotalPrice += CalcRepairGold(spItem);
     UpdateGoldValue();
 
     CN3UIWndBase::AllHighLightIconFree();
@@ -261,28 +261,21 @@ bool CUIItemExchange::ReceiveIconDrop(__IconItemSkill * spItem, POINT ptCur) {
 }
 
 void CUIItemExchange::UpdateGoldValue() {
-    char          szGold[32];
     CN3UIString * pStrGold = (CN3UIString *)GetChildByID("string_gold");
     __ASSERT(pStrGold, "NULL UI Component!!");
-
     if (pStrGold) {
         // 돈 업데이트..
-        sprintf(szGold, "%d", m_pTotalPrice);
-        pStrGold->SetString(szGold);
+        pStrGold->SetString(::_FormatCoins(m_iTotalPrice));
     }
 }
 
 void CUIItemExchange::UpdateUserTotalGold(int iGold) {
-    char          szGold[32];
-    CN3UIString * pStatic = NULL;
-
     // 돈 업데이트..
     CGameBase::s_pPlayer->m_InfoExt.iGold = iGold;
-    sprintf(szGold, "%d", iGold);
-    pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
+    CN3UIString * pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pStatic, "NULL UI Component!!");
     if (pStatic) {
-        pStatic->SetString(szGold);
+        pStatic->SetString(::_FormatCoins(iGold));
     }
 }
 
@@ -413,7 +406,7 @@ void CUIItemExchange::Open() {
         m_pMyNpcWndOriginIndex[i] = -1;
     }
 
-    m_pTotalPrice = 0;
+    m_iTotalPrice = 0;
     UpdateGoldValue();
 
     // 인벤토리 inv 영역의 아이템을 이 윈도우의 inv영역으로 옮긴다..

--- a/src/game/UIItemExchange.h
+++ b/src/game/UIItemExchange.h
@@ -20,7 +20,7 @@ class CUIItemExchange : public CN3UIWndBase {
     __IconItemSkill *    m_pMyInvWnd[MAX_ITEM_INVENTORY];
     __IconItemSkill *    m_pMyNpcWnd[MAX_ITEM_EX_RE_NPC];
     int                  m_pMyNpcWndOriginIndex[MAX_ITEM_EX_RE_NPC];
-    int                  m_pTotalPrice;
+    int                  m_iTotalPrice;
     CUIImageTooltipDlg * m_pUITooltipDlg;
 
   private:

--- a/src/game/UIItemExchange.h
+++ b/src/game/UIItemExchange.h
@@ -20,7 +20,7 @@ class CUIItemExchange : public CN3UIWndBase {
     __IconItemSkill *    m_pMyInvWnd[MAX_ITEM_INVENTORY];
     __IconItemSkill *    m_pMyNpcWnd[MAX_ITEM_EX_RE_NPC];
     int                  m_pMyNpcWndOriginIndex[MAX_ITEM_EX_RE_NPC];
-    int                  m_iTotalPrice;
+    int64_t              m_iTotalPrice;
     CUIImageTooltipDlg * m_pUITooltipDlg;
 
   private:
@@ -60,9 +60,9 @@ class CUIItemExchange : public CN3UIWndBase {
 
     int  CalcRepairGold(__IconItemSkill * spItem);
     void UpdateGoldValue();
-    void UpdateUserTotalGold(int iGold);
+    void UpdateUserTotalGold(int64_t iGold);
 
     void UserPressCancel(); // And User Press Close.. ^^
     void UserPressOK();
-    void ReceiveResultFromServer(int iResult, int iUserGold);
+    void ReceiveResultFromServer(int iResult, int64_t iUserGold);
 };

--- a/src/game/UILoading.cpp
+++ b/src/game/UILoading.cpp
@@ -42,9 +42,7 @@ bool CUILoading::Load(HANDLE hFile) {
     m_pText_Version = (CN3UIString *)(CN3UIBase::GetChildByID("Text_Version"));
     __ASSERT(m_pText_Version, "NULL UI Component!!");
     if (m_pText_Version) {
-        char szVersion[128];
-        sprintf(szVersion, "Ver. %.3f", CURRENT_VERSION / 1000.0f);
-        m_pText_Version->SetString(szVersion);
+        m_pText_Version->SetString(std::format("Ver. {:.3f}", CURRENT_VERSION / 1000.0f));
     }
     m_pText_Info = (CN3UIString *)(CN3UIBase::GetChildByID("Text_Info"));
     __ASSERT(m_pText_Info, "NULL UI Component!!");

--- a/src/game/UIPartyBBS.cpp
+++ b/src/game/UIPartyBBS.cpp
@@ -75,10 +75,8 @@ bool CUIPartyBBS::Load(HANDLE hFile) {
     m_pText_Page = (CN3UIString *)(pParty->GetChildByID("string_page"));
     __ASSERT(m_pText_Page, "NULL UI Component!!!");
 
-    char szBuf[64];
     for (int i = 0; i < PARTY_BBS_MAXSTRING; i++) {
-        sprintf(szBuf, "text_%.2d", i);
-        m_pText[i] = (CN3UIString *)(pParty->GetChildByID(szBuf));
+        m_pText[i] = (CN3UIString *)(pParty->GetChildByID(std::format("text_{:02d}", i)));
     }
 
     m_iCurPage = 0; // 현재 페이지..
@@ -332,9 +330,7 @@ void CUIPartyBBS::SetContentString(int iIndex, std::string szID, int iLevel, std
     }
 
     if (m_pText[iIndex + PARTY_BBS_MAXLINE]) {
-        char szBuf[20];
-        sprintf(szBuf, "%d", iLevel);
-        m_pText[iIndex + PARTY_BBS_MAXLINE]->SetString(szBuf);
+        m_pText[iIndex + PARTY_BBS_MAXLINE]->SetStringAsInt(iLevel);
     }
 
     if (m_pText[iIndex + PARTY_BBS_MAXLINE * 2]) {

--- a/src/game/UIPerTradeDlg.cpp
+++ b/src/game/UIPerTradeDlg.cpp
@@ -376,14 +376,13 @@ void CUIPerTradeDlg::ItemMoveFromThisToInv() {
 }
 
 void CUIPerTradeDlg::ItemCountOK() {
-    int iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
-
-    __IconItemSkill *spItem, *spItemNew = NULL;
-    spItem = m_pPerTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
-
+    int64_t iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
     if (iGold <= 0) {
         return;
     }
+
+    __IconItemSkill *spItem, *spItemNew = NULL;
+    spItem = m_pPerTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder];
     if (iGold > spItem->iCount) {
         return;
     }

--- a/src/game/UIPerTradeDlg.cpp
+++ b/src/game/UIPerTradeDlg.cpp
@@ -313,18 +313,14 @@ void CUIPerTradeDlg::EnterPerTradeState() {
 
     ItemMoveFromInvToThis();
 
-    char szGold[32];
-    sprintf(szGold, "%d", CGameBase::s_pPlayer->m_InfoExt.iGold);
     if (m_pStrMyGold) {
-        m_pStrMyGold->SetString(szGold);
+        m_pStrMyGold->SetString(::_FormatCoins(CGameBase::s_pPlayer->m_InfoExt.iGold));
     }
 }
 
 void CUIPerTradeDlg::GoldUpdate() {
-    char szGold[32];
-    sprintf(szGold, "%d", CGameBase::s_pPlayer->m_InfoExt.iGold);
     if (m_pStrMyGold) {
-        m_pStrMyGold->SetString(szGold);
+        m_pStrMyGold->SetString(::_FormatCoins(CGameBase::s_pPlayer->m_InfoExt.iGold));
     }
 }
 

--- a/src/game/UIPointInitDlg.cpp
+++ b/src/game/UIPointInitDlg.cpp
@@ -102,15 +102,8 @@ bool CUIPointInitDlg::OnKeyPress(int iKey) {
 
 void CUIPointInitDlg::InitDlg(bool bAllpoint, int iGold) {
     m_bAllpoint = bAllpoint;
-    if (m_pText_NeedGold) {
-        switch (bAllpoint) {
-        case true:
-            m_pText_NeedGold->SetStringAsInt(iGold);
-            break;
-        case false:
-            m_pText_NeedGold->SetStringAsInt(iGold);
-            break;
-        }
+    if (m_pText_NeedGold && bAllpoint) {
+        m_pText_NeedGold->SetString(::_FormatCoins(iGold));
     }
 }
 

--- a/src/game/UISkillTreeDlg.cpp
+++ b/src/game/UISkillTreeDlg.cpp
@@ -776,40 +776,38 @@ void CUISkillTreeDlg::CheckButtonTooltipRenderEnable() {
 }
 
 void CUISkillTreeDlg::ButtonTooltipRender(int iIndex) {
-    std::string szStr;
-    char        pszDesc[256];
-    memset(pszDesc, 0, sizeof(char) * 256);
+    std::string szFmt, szStr;
     if (!m_pStr_info->IsVisible()) {
         m_pStr_info->SetVisible(true);
     }
 
     switch (iIndex) {
     case SKILL_DEF_BASIC:
-        ::_LoadStringFromResource(IDS_SKILL_INFO_BASE, szStr);
-        sprintf(pszDesc, szStr.c_str());
+        ::_LoadStringFromResource(IDS_SKILL_INFO_BASE, szFmt);
+        szStr = szFmt;
         break;
 
     case SKILL_DEF_SPECIAL0:
         switch (CGameBase::s_pPlayer->m_InfoBase.eClass) {
         case CLASS_EL_BLADE:
         case CLASS_KA_BERSERKER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE0, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE0, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_RANGER:
         case CLASS_KA_HUNTER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER0, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER0, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_CLERIC:
         case CLASS_KA_SHAMAN:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC0, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC0, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_MAGE:
         case CLASS_KA_SORCERER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE0, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE0, szFmt);
+            szStr = szFmt;
             break;
         }
         break;
@@ -818,23 +816,23 @@ void CUISkillTreeDlg::ButtonTooltipRender(int iIndex) {
         switch (CGameBase::s_pPlayer->m_InfoBase.eClass) {
         case CLASS_EL_BLADE:
         case CLASS_KA_BERSERKER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE1, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE1, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_RANGER:
         case CLASS_KA_HUNTER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER1, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER1, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_CLERIC:
         case CLASS_KA_SHAMAN:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC1, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC1, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_MAGE:
         case CLASS_KA_SORCERER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE1, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE1, szFmt);
+            szStr = szFmt;
             break;
         }
         break;
@@ -843,23 +841,23 @@ void CUISkillTreeDlg::ButtonTooltipRender(int iIndex) {
         switch (CGameBase::s_pPlayer->m_InfoBase.eClass) {
         case CLASS_EL_BLADE:
         case CLASS_KA_BERSERKER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE2, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE2, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_RANGER:
         case CLASS_KA_HUNTER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER2, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER2, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_CLERIC:
         case CLASS_KA_SHAMAN:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC2, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC2, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_MAGE:
         case CLASS_KA_SORCERER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE2, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE2, szFmt);
+            szStr = szFmt;
             break;
         }
         break;
@@ -868,29 +866,29 @@ void CUISkillTreeDlg::ButtonTooltipRender(int iIndex) {
         switch (CGameBase::s_pPlayer->m_InfoBase.eClass) {
         case CLASS_EL_BLADE:
         case CLASS_KA_BERSERKER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE3, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_BLADE3, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_RANGER:
         case CLASS_KA_HUNTER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER3, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_RANGER3, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_CLERIC:
         case CLASS_KA_SHAMAN:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC3, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_CLERIC3, szFmt);
+            szStr = szFmt;
             break;
         case CLASS_EL_MAGE:
         case CLASS_KA_SORCERER:
-            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE3, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_INFO_MAGE3, szFmt);
+            szStr = szFmt;
             break;
         }
         break;
     }
 
-    m_pStr_info->SetString(pszDesc);
+    m_pStr_info->SetString(szStr);
     m_pStr_info->Render();
 }
 
@@ -899,26 +897,25 @@ void CUISkillTreeDlg::TooltipRenderEnable(__IconItemSkill * spSkill) {
         return;
     }
 
-    std::string szStr;
+    std::string szFmt;
     bool        bFound = false;
 
-    char pszDesc[256];
+    char pszDesc[256]{};
     if (!m_pStr_info->IsVisible()) {
         m_pStr_info->SetVisible(true);
     }
-    sprintf(pszDesc, "%s", spSkill->pSkill->szDesc.c_str());
-    m_pStr_info->SetString(pszDesc);
+    m_pStr_info->SetString(spSkill->pSkill->szDesc);
 
     if ((spSkill->pSkill->dw1stTableType != 1) && (spSkill->pSkill->dw1stTableType != 2)) {
         if (!m_pStr_skill_mp->IsVisible()) {
             m_pStr_skill_mp->SetVisible(true);
         }
         if (spSkill->pSkill->iExhaustMSP == 0) {
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NO_MANA, szStr);
-            sprintf(pszDesc, "%s", szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NO_MANA, szFmt);
+            sprintf(pszDesc, "%s", szFmt.c_str());
         } else {
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_USE_MANA, szStr);
-            sprintf(pszDesc, szStr.c_str(), spSkill->pSkill->iExhaustMSP);
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_USE_MANA, szFmt);
+            sprintf(pszDesc, szFmt.c_str(), spSkill->pSkill->iExhaustMSP);
         }
         m_pStr_skill_mp->SetString(pszDesc);
     }
@@ -929,15 +926,15 @@ void CUISkillTreeDlg::TooltipRenderEnable(__IconItemSkill * spSkill) {
     switch (spSkill->pSkill->iNeedSkill) {
     case 1055:
     case 2055:
-        ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_DUAL, szStr);
-        sprintf(pszDesc, szStr.c_str());
+        ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_DUAL, szFmt);
+        sprintf(pszDesc, szFmt.c_str());
         bFound = true;
         break;
 
     case 1056:
     case 2056:
-        ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_DOUBLE, szStr);
-        sprintf(pszDesc, szStr.c_str());
+        ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_DOUBLE, szFmt);
+        sprintf(pszDesc, szFmt.c_str());
         bFound = true;
         break;
     }
@@ -945,72 +942,72 @@ void CUISkillTreeDlg::TooltipRenderEnable(__IconItemSkill * spSkill) {
     if (!bFound) {
         switch (spSkill->pSkill->dwNeedItem) {
         case 0:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID1, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID1, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 1:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID2, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID2, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 2:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID3, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID3, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 3:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID4, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID4, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 4:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID5, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID5, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 5:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID6, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID6, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 6:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID7, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID7, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 7:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID8, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID8, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 8:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID9, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID9, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 10:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID10, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID10, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 11:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID11, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID11, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 12:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID12, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID12, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 13:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID13, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID13, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 21:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID14, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID14, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 22:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID15, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID15, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 23:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID16, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID16, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         case 24:
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID17, szStr);
-            sprintf(pszDesc, szStr.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_NEED_ITEM_ID17, szFmt);
+            sprintf(pszDesc, szFmt.c_str());
             break;
         default:
             sprintf(pszDesc, "");
@@ -1023,14 +1020,14 @@ void CUISkillTreeDlg::TooltipRenderEnable(__IconItemSkill * spSkill) {
         m_pStr_skill_item1->SetVisible(true);
     }
     if (spSkill->pSkill->dwExhaustItem == 0) {
-        ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_USE_ITEM_NO, szStr);
-        sprintf(pszDesc, szStr.c_str());
+        ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_USE_ITEM_NO, szFmt);
+        sprintf(pszDesc, szFmt.c_str());
     } else {
         __TABLE_ITEM_BASIC * pItem = NULL;
         pItem = CGameBase::s_pTbl_Items_Basic->Find(spSkill->pSkill->dwExhaustItem);
         if (pItem) {
-            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_USE_ITEM_EXIST, szStr);
-            sprintf(pszDesc, szStr.c_str(), pItem->szName.c_str());
+            ::_LoadStringFromResource(IDS_SKILL_TOOLTIP_USE_ITEM_EXIST, szFmt);
+            sprintf(pszDesc, szFmt.c_str(), pItem->szName.c_str());
         } else {
             __ASSERT(0, "NULL Item!!!");
         }
@@ -1450,9 +1447,7 @@ stop:
     spSkill->pSkill = pUSkill;
 
     // 아이콘 이름 만들기.. ^^
-    char buffer[MAX_PATH]{};
-    sprintf(buffer, "UI\\skillicon_%.2d_%d.dxt", pUSkill->dwID % 100, pUSkill->dwID / 100);
-    spSkill->szIconFN = buffer;
+    spSkill->szIconFN = std::format("UI\\skillicon_{:02d}_{:d}.dxt", pUSkill->dwID % 100, pUSkill->dwID / 100);
 
     // 아이콘 로드하기.. ^^
     spSkill->pUIIcon = new CN3UIIcon;
@@ -1594,24 +1589,15 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum) // 아이콘 �
     }
 
     // 아이콘 설명 문자열 업데이트.. 현재 스킬 종류와 현재 스킬 페이지중 아이콘이 보이면 String보이게.. 아니면 안보이게..
-    CN3UIString * pStrName;
-    std::string   str;
-    char          cstr[4];
-
+    CN3UIString * pStrName = NULL;
     for (int k = 0; k < MAX_SKILL_IN_PAGE; k++) {
         if (m_pMySkillTree[m_iCurKindOf][m_iCurSkillPage][k] != NULL) {
-            str = "string_list_";
-            sprintf(cstr, "%d", k);
-            str += cstr;
-            pStrName = (CN3UIString *)GetChildByID(str);
+            pStrName = (CN3UIString *)GetChildByID(std::format("string_list_{}", k));
             __ASSERT(pStrName, "NULL UI Component!!");
             pStrName->SetString(m_pMySkillTree[m_iCurKindOf][m_iCurSkillPage][k]->pSkill->szName);
             pStrName->SetVisible(true);
         } else {
-            str = "string_list_";
-            sprintf(cstr, "%d", k);
-            str += cstr;
-            pStrName = (CN3UIString *)GetChildByID(str);
+            pStrName = (CN3UIString *)GetChildByID(std::format("string_list_{}", k));
             __ASSERT(pStrName, "NULL UI Component!!");
             pStrName->SetVisible(false);
         }
@@ -1621,44 +1607,29 @@ void CUISkillTreeDlg::SetPageInIconRegion(int iKindOf, int iPageNum) // 아이콘 �
 
     CN3UIString * pStr = (CN3UIString *)GetChildByID("string_page");
     __ASSERT(pStr, "NULL UI Component!!");
-    sprintf(cstr, "%d", iPageNum + 1);
     if (pStr) {
-        pStr->SetString(cstr);
+        pStr->SetStringAsInt(iPageNum + 1);
     }
 }
 
 void CUISkillTreeDlg::AllClearImageByName(const std::string & szFN, bool bTrueOrNot) {
     //    CN3UIImage* pImage;
-    CN3UIBase *   pBase;
-    CN3UIButton * pButton;
-
-    std::string str;
-    char        cstr[4];
-
+    CN3UIBase *   pBase = NULL;
+    CN3UIButton * pButton = NULL;
     for (int i = 0; i < 4; i++) {
-        str = "img_";
-        str += szFN;
-        sprintf(cstr, "_%d", i);
-        str += cstr;
-        pBase = GetChildBaseByName(str);
+        pBase = GetChildBaseByName(std::format("img_{}{}", szFN, i));
         if (pBase) {
             pBase->SetVisible(bTrueOrNot);
         }
     }
 
-    str = "img_";
-    str += szFN;
-    pBase = GetChildBaseByName(str);
+    pBase = GetChildBaseByName("img_" + szFN);
     if (pBase) {
         pBase->SetVisible(bTrueOrNot);
     }
 
     for (int i = 0; i < 4; i++) {
-        str = "btn_";
-        str += szFN;
-        sprintf(cstr, "%d", i);
-        str += cstr;
-        pButton = GetChildButtonByName(str);
+        pButton = GetChildButtonByName(std::format("btn_{}{}", szFN, i));
         if (pButton) {
             pButton->SetVisible(bTrueOrNot);
         }

--- a/src/game/UIStateBar.cpp
+++ b/src/game/UIStateBar.cpp
@@ -132,9 +132,7 @@ bool CUIStateBar::Load(HANDLE hFile) {
     CN3UIString * pText = (CN3UIString *)(this->GetChildByID("Text_Version"));
     __ASSERT(pText, "NULL UI Component!!");
     if (pText) {
-        char szVersion[128];
-        sprintf(szVersion, "Ver. %.3f", CURRENT_VERSION / 1000.0f);
-        pText->SetString(szVersion);
+        pText->SetString(std::format("Ver. {:.3f}", CURRENT_VERSION / 1000.0f));
     }
     m_pText_Position = (CN3UIString *)(this->GetChildByID("Text_Position"));
     __ASSERT(m_pText_Position, "NULL UI Component!!");
@@ -248,7 +246,7 @@ void CUIStateBar::UpdateExp(int iExp, int iExpNext, bool bUpdateImmediately) {
     }
 
     if (m_pText_ExpP) {
-        m_pText_ExpP->SetString(std::to_string(iPercentage) + "%");
+        m_pText_ExpP->SetString(std::format("{} %", iPercentage));
     }
 }
 
@@ -270,7 +268,7 @@ void CUIStateBar::UpdateMSP(int iMSP, int iMSPMax, bool bUpdateImmediately) {
     }
 
     if (m_pText_MSP) {
-        m_pText_MSP->SetString(std::to_string(iMSP) + " / " + std::to_string(iMSPMax));
+        m_pText_MSP->SetString(std::format("{} / {}", iMSP, iMSPMax));
     }
 }
 
@@ -289,7 +287,7 @@ void CUIStateBar::UpdateHP(int iHP, int iHPMax, bool bUpdateImmediately) {
     }
 
     if (m_pText_HP) {
-        m_pText_HP->SetString(std::to_string(iHP) + " / " + std::to_string(iHPMax));
+        m_pText_HP->SetString(std::format("{} / {}", iHP, iHPMax));
     }
 }
 
@@ -298,9 +296,7 @@ void CUIStateBar::UpdatePosition(const __Vector3 & vPos, float fYaw) {
         return;
     }
 
-    char szPos[64]{};
-    sprintf(szPos, "%d, %d", (int)vPos.x, (int)vPos.z);
-    m_pText_Position->SetString(szPos);
+    m_pText_Position->SetString(std::format("{}, {}", (int)vPos.x, (int)vPos.z));
 
     // ¹Ì´Ï¸Ê.
     m_vPosPlayer = vPos;
@@ -477,23 +473,18 @@ void CUIStateBar::Tick() {
 
     m_fFPSValue += s_fSecPerFrm;
     if (m_fFPSValue > 1.0f) {
-        char szBuff[12]{};
-        sprintf(szBuff, "%.1f", s_fFrmPerSec);
-        m_pText_Fps->SetString(szBuff);
+        m_pText_Fps->SetString(std::format("{:.1f}", s_fFrmPerSec));
         m_fFPSValue = 0.0f;
     }
 
     if (m_bShowSystemTime) {
-        char szBuff[12]{};
-        sprintf(szBuff, "%.1f", CN3Base::TimeGet());
-
         // The official client implements this as the line above.
         // However printing actual system time as per @xGuTeK PR is not a bad idea either.
         // Leaving it here as a comment in order to stick to the official behavior for now.
         //time_t timer = time(NULL);
         //strftime(szBuff, sizeof(szBuff), "%H:%M:%S", localtime(&timer));
 
-        m_pText_SystemTime->SetString(szBuff);
+        m_pText_SystemTime->SetString(std::format("{:.1f}", CN3Base::TimeGet()));
     }
 
     if (CGameBase::s_pPlayer && !m_bQuestButtonClicked && m_bQuestButtonBlink) {
@@ -703,11 +694,7 @@ void CUIStateBar::SetSystemTimeVisibility(bool bVisible) {
 }
 
 void CUIStateBar::AddMagic(__TABLE_UPC_SKILL * pSkill, float fDuration) {
-    // TODO: Change instances like these to std::format once upgrading to cpp20:
-    // https://en.cppreference.com/w/cpp/utility/format/format
-    char buffer[MAX_PATH]{};
-    sprintf(buffer, "UI\\skillicon_%.2d_%d.dxt", pSkill->dwID % 100, pSkill->dwID / 100);
-
+    std::string          szTexFN = std::format("UI\\skillicon_{:02d}_{:d}.dxt", pSkill->dwID % 100, pSkill->dwID / 100);
     __DurationMagicImg * pMagicImg = new __DurationMagicImg;
     pMagicImg->fDuration = fDuration;
     pMagicImg->pIcon = new CN3UIDBCLButton;
@@ -715,7 +702,7 @@ void CUIStateBar::AddMagic(__TABLE_UPC_SKILL * pSkill, float fDuration) {
 
     CN3UIDBCLButton * pIcon = pMagicImg->pIcon;
     pIcon->Init(this);
-    pIcon->SetTex(buffer);
+    pIcon->SetTex(szTexFN);
     pIcon->SetTooltipText(pSkill->szName.c_str());
     pIcon->SetUVRect(0, 0, 1, 1);
 
@@ -738,8 +725,7 @@ void CUIStateBar::AddMagic(__TABLE_UPC_SKILL * pSkill, float fDuration) {
 }
 
 void CUIStateBar::DelMagic(__TABLE_UPC_SKILL * pSkill) {
-    char buffer[MAX_PATH]{};
-    sprintf(buffer, "UI\\skillicon_%.2d_%d.dxt", pSkill->dwID % 100, pSkill->dwID / 100);
+    std::string szTexFN = std::format("UI\\skillicon_{:02d}_{:d}.dxt", pSkill->dwID % 100, pSkill->dwID / 100);
 
     it_MagicImg it, ite, itRemove;
     itRemove = ite = m_pMagic.end();
@@ -747,7 +733,7 @@ void CUIStateBar::DelMagic(__TABLE_UPC_SKILL * pSkill) {
         __DurationMagicImg * pMagicImg = (*it);
         CN3UIDBCLButton *    pIcon = pMagicImg->pIcon;
         CN3Texture *         pTex = pIcon->GetTex();
-        if (pTex && lstrcmpi(pTex->FileName().c_str(), buffer) == 0) {
+        if (pTex && N3::iequals(szTexFN, pTex->FileName())) {
             itRemove = it;
         }
         if (itRemove != ite) {

--- a/src/game/UITradeEditDlg.cpp
+++ b/src/game/UITradeEditDlg.cpp
@@ -49,10 +49,7 @@ void CUITradeEditDlg::SetQuantity(int iQuantity) // "edit_trade" Edit Control ¿¡
 {
     CN3UIEdit * pEdit = (CN3UIEdit *)this->GetChildByID("edit_trade");
     __ASSERT(pEdit, "NULL UI Component!!");
-
-    char szBuff[64] = "";
-    sprintf(szBuff, "%d", iQuantity);
-    pEdit->SetString(szBuff);
+    pEdit->SetString(std::to_string(iQuantity));
 }
 
 bool CUITradeEditDlg::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {

--- a/src/game/UITradeSellBBS.cpp
+++ b/src/game/UITradeSellBBS.cpp
@@ -92,10 +92,8 @@ bool CUITradeSellBBS::Load(HANDLE hFile) {
     m_pString_Page = (CN3UIString *)(this->GetChildByID("string_page"));
     __ASSERT(m_pString_Page, "NULL UI Component!!!");
 
-    char szBuf[64];
     for (int i = 0; i < TRADE_BBS_MAXSTRING; i++) {
-        sprintf(szBuf, "text_%.2d", i);
-        m_pText[i] = (CN3UIString *)(this->GetChildByID(szBuf));
+        m_pText[i] = (CN3UIString *)(this->GetChildByID(std::format("text_{:02d}", i)));
     }
 
     m_iCurPage = 0; // 현재 페이지..

--- a/src/game/UITransactionDlg.cpp
+++ b/src/game/UITransactionDlg.cpp
@@ -331,7 +331,7 @@ void CUITransactionDlg::EnterTransactionState() {
 
     if (m_pStrMyGold) {
         __InfoPlayerMySelf * pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
-        m_pStrMyGold->SetStringAsInt(pInfoExt->iGold);
+        m_pStrMyGold->SetString(::_FormatCoins(pInfoExt->iGold));
     }
 
     switch ((int)(m_iTradeID / 1000)) {
@@ -349,8 +349,7 @@ void CUITransactionDlg::EnterTransactionState() {
 
 void CUITransactionDlg::GoldUpdate() {
     if (m_pStrMyGold) {
-        __InfoPlayerMySelf * pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
-        m_pStrMyGold->SetStringAsInt(pInfoExt->iGold);
+        m_pStrMyGold->SetString(::_FormatCoins(CGameBase::s_pPlayer->m_InfoExt.iGold));
     }
 }
 
@@ -1121,10 +1120,10 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(uint8_t bResult, uint8_t bT
             pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
             __ASSERT(pStatic, "NULL UI Component!!");
             if (pStatic) {
-                pStatic->SetStringAsInt(pInfoExt->iGold);
+                pStatic->SetString(::_FormatCoins(pInfoExt->iGold));
             }
             if (m_pStrMyGold) {
-                m_pStrMyGold->SetStringAsInt(pInfoExt->iGold); // 상거래창..
+                m_pStrMyGold->SetString(::_FormatCoins(pInfoExt->iGold)); // 상거래창..
             }
         }
 
@@ -1188,10 +1187,10 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(uint8_t bResult, uint8_t bT
             pStatic = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
             __ASSERT(pStatic, "NULL UI Component!!");
             if (pStatic) {
-                pStatic->SetStringAsInt(pInfoExt->iGold);
+                pStatic->SetString(::_FormatCoins(pInfoExt->iGold));
             }
             if (m_pStrMyGold) {
-                m_pStrMyGold->SetStringAsInt(pInfoExt->iGold); // 상거래창..
+                m_pStrMyGold->SetString(::_FormatCoins(pInfoExt->iGold)); // 상거래창..
             }
         }
 

--- a/src/game/UITransactionDlg.cpp
+++ b/src/game/UITransactionDlg.cpp
@@ -431,7 +431,7 @@ void CUITransactionDlg::ItemMoveFromThisToInv() {
 }
 
 void CUITransactionDlg::ItemCountOK() {
-    int                  iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
+    int64_t              iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
     __IconItemSkill *    spItem, *spItemNew = NULL;
     __InfoPlayerMySelf * pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
     int                  iWeight;
@@ -1066,7 +1066,7 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(uint8_t bResult, uint8_t bT
         {
             if ((CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) ||
                 (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL)) {
-                int iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
+                int64_t iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
 
                 if ((m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceEnd.iOrder]->iCount - iGold) > 0) {
                     //  숫자 업데이트..
@@ -1136,7 +1136,7 @@ void CUITransactionDlg::ReceiveResultTradeFromServer(uint8_t bResult, uint8_t bT
         {
             if ((CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE) ||
                 (CN3UIWndBase::m_sRecoveryJobInfo.pItemSource->pItemBasic->byContable == UIITEM_TYPE_COUNTABLE_SMALL)) {
-                int iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
+                int64_t iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
 
                 if (m_pMyTradeInv[CN3UIWndBase::m_sRecoveryJobInfo.UIWndSourceStart.iOrder]
                         ->pUIIcon->IsVisible()) // 기존 아이콘이 보인다면..

--- a/src/game/UITransactionDlg.cpp
+++ b/src/game/UITransactionDlg.cpp
@@ -308,9 +308,7 @@ void CUITransactionDlg::EnterTransactionState() {
     m_iCurPage = 0;
     CN3UIString * pStr = (CN3UIString *)GetChildByID("string_page");
     if (pStr) {
-        char pszID[32];
-        sprintf(pszID, "%d", m_iCurPage + 1);
-        pStr->SetString(pszID);
+        pStr->SetStringAsInt(m_iCurPage + 1);
     }
 
     for (int j = 0; j < MAX_ITEM_TRADE_PAGE; j++) {
@@ -1346,9 +1344,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
 
             pStr = (CN3UIString *)GetChildByID("string_page");
             if (pStr) {
-                char pszID[32];
-                sprintf(pszID, "%d", m_iCurPage + 1);
-                pStr->SetString(pszID);
+                pStr->SetStringAsInt(m_iCurPage + 1);
             }
 
             for (int j = 0; j < MAX_ITEM_TRADE_PAGE; j++) {
@@ -1376,9 +1372,7 @@ bool CUITransactionDlg::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
 
             pStr = (CN3UIString *)GetChildByID("string_page");
             if (pStr) {
-                char pszID[32];
-                sprintf(pszID, "%d", m_iCurPage + 1);
-                pStr->SetString(pszID);
+                pStr->SetStringAsInt(m_iCurPage + 1);
             }
 
             for (int j = 0; j < MAX_ITEM_TRADE_PAGE; j++) {

--- a/src/game/UIWareHouseDlg.cpp
+++ b/src/game/UIWareHouseDlg.cpp
@@ -335,9 +335,7 @@ bool CUIWareHouseDlg::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
 
             pStr = (CN3UIString *)GetChildByID("string_page");
             if (pStr) {
-                char pszID[32];
-                sprintf(pszID, "%d", m_iCurPage + 1);
-                pStr->SetString(pszID);
+                pStr->SetStringAsInt(m_iCurPage + 1);
             }
 
             for (int j = 0; j < MAX_ITEM_WARE_PAGE; j++) {
@@ -365,9 +363,7 @@ bool CUIWareHouseDlg::ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg) {
 
             pStr = (CN3UIString *)GetChildByID("string_page");
             if (pStr) {
-                char pszID[32];
-                sprintf(pszID, "%d", m_iCurPage + 1);
-                pStr->SetString(pszID);
+                pStr->SetStringAsInt(m_iCurPage + 1);
             }
 
             for (int j = 0; j < MAX_ITEM_WARE_PAGE; j++) {

--- a/src/game/UIWareHouseDlg.cpp
+++ b/src/game/UIWareHouseDlg.cpp
@@ -494,7 +494,7 @@ void CUIWareHouseDlg::EnterWareHouseStateStart(int iWareGold) {
     }
 
     if (m_pStrWareGold) {
-        m_pStrWareGold->SetStringAsInt(iWareGold);
+        m_pStrWareGold->SetString(::_FormatCoins(iWareGold));
     }
 }
 
@@ -504,9 +504,7 @@ void CUIWareHouseDlg::EnterWareHouseStateEnd() {
     m_iCurPage = 0;
     CN3UIString * pStr = (CN3UIString *)GetChildByID("string_page");
     if (pStr) {
-        char pszID[32];
-        sprintf(pszID, "%d", m_iCurPage + 1);
-        pStr->SetString(pszID);
+        pStr->SetStringAsInt(m_iCurPage + 1);
     }
 
     for (int j = 0; j < MAX_ITEM_WARE_PAGE; j++) {
@@ -529,7 +527,7 @@ void CUIWareHouseDlg::EnterWareHouseStateEnd() {
 
     if (m_pStrMyGold) {
         __InfoPlayerMySelf * pInfoExt = &(CGameBase::s_pPlayer->m_InfoExt);
-        m_pStrMyGold->SetStringAsInt(pInfoExt->iGold);
+        m_pStrMyGold->SetString(::_FormatCoins(pInfoExt->iGold));
     }
 }
 
@@ -1713,9 +1711,7 @@ void CUIWareHouseDlg::AddItemInWare(int iItem, int iDurability, int iCount, int 
 
 void CUIWareHouseDlg::GoldCountToWareOK() //돈을 넣는 경우..
 {
-    char        szGold[32];
-    int         iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
-    std::string str;
+    int iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
 
     // 돈을 보관함에 보관하는 경우..
     iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
@@ -1727,16 +1723,10 @@ void CUIWareHouseDlg::GoldCountToWareOK() //돈을 넣는 경우..
     iMyMoney = CGameBase::s_pPlayer->m_InfoExt.iGold;
 
     // 보관함의 돈을 얻어온다..
-    CN3UIString * pStr = NULL;
-    pStr = (CN3UIString *)GetChildByID("string_wareitem_name");
+    CN3UIString * pStr = (CN3UIString *)GetChildByID("string_wareitem_name");
     __ASSERT(pStr, "NULL UI Component!!");
-    str = pStr->GetString();
-    iWareMoney = atoi(str.c_str());
-
-    if (iGold <= 0) {
-        return;
-    }
-    if (iGold > iMyMoney) {
+    iWareMoney = pStr->GetStringAsInt({','});
+    if (iGold <= 0 || iGold > iMyMoney) {
         return;
     }
 
@@ -1745,26 +1735,23 @@ void CUIWareHouseDlg::GoldCountToWareOK() //돈을 넣는 경우..
     // 돈을 감소 시킨다..
     iMyMoney -= iGold;
     CGameBase::s_pPlayer->m_InfoExt.iGold = iMyMoney;
-
     iWareMoney += iGold;
 
     // 돈 표시.. Ware..
-    pStr->SetStringAsInt(iWareMoney);
+    pStr->SetString(::_FormatCoins(iWareMoney));
+
     // 돈 표시.. 인벤토리..
-    sprintf(szGold, "%d", iMyMoney);
-    pStr = NULL;
-    str = szGold;
     pStr = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetString(str);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
-    pStr = NULL;
+
     // 돈 표시.. Inv..
     pStr = (CN3UIString *)GetChildByID("string_item_name");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetStringAsInt(iMyMoney);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
 
     // 서버에게 패킷 만들어서 날림..
@@ -1779,9 +1766,7 @@ void CUIWareHouseDlg::GoldCountToWareOK() //돈을 넣는 경우..
 
 void CUIWareHouseDlg::GoldCountFromWareOK() // 돈을 빼는 경우..
 {
-    char        szGold[32];
-    int         iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
-    std::string str;
+    int iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
 
     // 돈을 보관함에서 빼는 경우..
     iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
@@ -1793,16 +1778,10 @@ void CUIWareHouseDlg::GoldCountFromWareOK() // 돈을 빼는 경우..
     iMyMoney = CGameBase::s_pPlayer->m_InfoExt.iGold;
 
     // 보관함의 돈을 얻어온다..
-    CN3UIString * pStr = NULL;
-    pStr = (CN3UIString *)GetChildByID("string_wareitem_name");
+    CN3UIString * pStr = (CN3UIString *)GetChildByID("string_wareitem_name");
     __ASSERT(pStr, "NULL UI Component!!");
-    str = pStr->GetString();
-    iWareMoney = atoi(str.c_str());
-
-    if (iGold <= 0) {
-        return;
-    }
-    if (iGold > iWareMoney) {
+    iWareMoney = pStr->GetStringAsInt({','});
+    if (iGold <= 0 || iGold > iWareMoney) {
         return;
     }
 
@@ -1815,22 +1794,20 @@ void CUIWareHouseDlg::GoldCountFromWareOK() // 돈을 빼는 경우..
     iWareMoney -= iGold;
 
     // 돈 표시.. Ware..
-    pStr->SetStringAsInt(iWareMoney);
+    pStr->SetString(::_FormatCoins(iWareMoney));
+
     // 돈 표시.. 인벤토리..
-    sprintf(szGold, "%d", iMyMoney);
-    pStr = NULL;
-    str = szGold;
     pStr = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetString(str);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
-    pStr = NULL;
+
     // 돈 표시.. Inv..
     pStr = (CN3UIString *)GetChildByID("string_item_name");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetStringAsInt(iMyMoney);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
 
     // 서버에게 패킷 만들어서 날림..
@@ -1870,11 +1847,9 @@ void CUIWareHouseDlg::GoldCountFromWareCancel() {
 }
 
 void CUIWareHouseDlg::ReceiveResultGoldToWareFail() {
-    m_bSendedItemGold = false; // 원래 대로..
+    int iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
 
-    char        szGold[32];
-    int         iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
-    std::string str;
+    m_bSendedItemGold = false; // 원래 대로..
 
     // 돈을 보관함에서 빼는 경우..
     iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
@@ -1889,8 +1864,7 @@ void CUIWareHouseDlg::ReceiveResultGoldToWareFail() {
     CN3UIString * pStr = NULL;
     pStr = (CN3UIString *)GetChildByID("string_wareitem_name");
     __ASSERT(pStr, "NULL UI Component!!");
-    str = pStr->GetString();
-    iWareMoney = atoi(str.c_str());
+    iWareMoney = pStr->GetStringAsInt({','});
 
     // 돈을 감소 시킨다..
     iMyMoney += iGold;
@@ -1899,31 +1873,27 @@ void CUIWareHouseDlg::ReceiveResultGoldToWareFail() {
     iWareMoney -= iGold;
 
     // 돈 표시.. Ware..
-    pStr->SetStringAsInt(iWareMoney);
+    pStr->SetString(::_FormatCoins(iWareMoney));
+
     // 돈 표시.. 인벤토리..
-    sprintf(szGold, "%d", iMyMoney);
-    pStr = NULL;
-    str = szGold;
     pStr = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetString(str);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
-    pStr = NULL;
+
     // 돈 표시.. Inv..
     pStr = (CN3UIString *)GetChildByID("string_item_name");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetStringAsInt(iMyMoney);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
 }
 
 void CUIWareHouseDlg::ReceiveResultGoldFromWareFail() {
-    m_bSendedItemGold = false; // 원래 대로..
+    int iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
 
-    char        szGold[32];
-    int         iGold, iMyMoney, iWareMoney; // 인벤토리의 값..
-    std::string str;
+    m_bSendedItemGold = false; // 원래 대로..
 
     // 돈을 보관함에 보관하는 경우..
     iGold = CN3UIWndBase::m_pCountableItemEdit->GetQuantity();
@@ -1938,8 +1908,7 @@ void CUIWareHouseDlg::ReceiveResultGoldFromWareFail() {
     CN3UIString * pStr = NULL;
     pStr = (CN3UIString *)GetChildByID("string_wareitem_name");
     __ASSERT(pStr, "NULL UI Component!!");
-    str = pStr->GetString();
-    iWareMoney = atoi(str.c_str());
+    iWareMoney = pStr->GetStringAsInt({','});
 
     // 돈을 감소 시킨다..
     iMyMoney -= iGold;
@@ -1948,22 +1917,20 @@ void CUIWareHouseDlg::ReceiveResultGoldFromWareFail() {
     iWareMoney += iGold;
 
     // 돈 표시.. Ware..
-    pStr->SetStringAsInt(iWareMoney);
+    pStr->SetString(::_FormatCoins(iWareMoney));
+
     // 돈 표시.. 인벤토리..
-    sprintf(szGold, "%d", iMyMoney);
-    pStr = NULL;
-    str = szGold;
     pStr = (CN3UIString *)CGameProcedure::s_pProcMain->m_pUIInventory->GetChildByID("text_gold");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetString(str);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
-    pStr = NULL;
+
     // 돈 표시.. Inv..
     pStr = (CN3UIString *)GetChildByID("string_item_name");
     __ASSERT(pStr, "NULL UI Component!!");
     if (pStr) {
-        pStr->SetStringAsInt(iMyMoney);
+        pStr->SetString(::_FormatCoins(iMyMoney));
     }
 }
 

--- a/src/game/UIWareHouseDlg.h
+++ b/src/game/UIWareHouseDlg.h
@@ -32,8 +32,8 @@ class CUIWareHouseDlg : public CN3UIWndBase {
     CN3UIButton * m_pBtnPageDown;
     //this_ui_add_end
 
-    bool m_bSendedItemGold;
-    int  m_iGoldOffsetBackup;
+    bool    m_bSendedItemGold;
+    int64_t m_iGoldOffsetBackup;
 
     int                  m_iCurPage;
     CUIImageTooltipDlg * m_pUITooltipDlg;
@@ -60,7 +60,7 @@ class CUIWareHouseDlg : public CN3UIWndBase {
     virtual bool  ReceiveMessage(CN3UIBase * pSender, DWORD dwMsg);
     void          Render();
     void          LeaveWareHouseState();
-    void          EnterWareHouseStateStart(int iWareGold);
+    void          EnterWareHouseStateStart(int64_t iWareGold);
     void          AddItemInWare(int iItem, int iDurability, int iCount, int iIndex);
     void          EnterWareHouseStateEnd();
 
@@ -76,8 +76,8 @@ class CUIWareHouseDlg : public CN3UIWndBase {
     void CancelIconDrop(__IconItemSkill * spItem);
     void AcceptIconDrop(__IconItemSkill * spItem);
 
-    void SendToServerToWareMsg(int iItemID, uint8_t page, uint8_t startpos, uint8_t pos, int iCount);
-    void SendToServerFromWareMsg(int iItemID, uint8_t page, uint8_t startpos, uint8_t pos, int iCount);
+    void SendToServerToWareMsg(int iItemID, uint8_t page, uint8_t startpos, uint8_t pos, int64_t iCount);
+    void SendToServerFromWareMsg(int iItemID, uint8_t page, uint8_t startpos, uint8_t pos, int64_t iCount);
     void SendToServerWareToWareMsg(int iItemID, uint8_t page, uint8_t startpos, uint8_t destpos);
     void SendToServerInvToInvMsg(int iItemID, uint8_t page, uint8_t startpos, uint8_t destpos);
     void ReceiveResultToWareMsg(BYTE bResult);

--- a/src/server/Ebenezer/User.cpp
+++ b/src/server/Ebenezer/User.cpp
@@ -1807,7 +1807,7 @@ void CUser::SendMyInfo() {
     SetByte(send_buff, m_bMagicR, send_index);
     SetByte(send_buff, m_bDiseaseR, send_index);
     SetByte(send_buff, m_bPoisonR, send_index);
-    SetDWORD(send_buff, m_pUserData->m_iGold, send_index);
+    SetInt64(send_buff, m_pUserData->m_iGold, send_index);
     // 이거 나중에 꼭 주석해 --;
     SetByte(send_buff, m_pUserData->m_bAuthority, send_index);
     //
@@ -4526,7 +4526,7 @@ void CUser::NpcEvent(char * pBuf) {
         /*
         SetByte( send_buf, WIZ_WAREHOUSE, send_index );
         SetByte( send_buf, WAREHOUSE_OPEN, send_index );
-        SetDWORD( send_buf, m_pUserData->m_iBank, send_index );
+        SetInt64( send_buf, m_pUserData->m_iBank, send_index );
         for(int i=0; i<WAREHOUSE_MAX; i++ ) {
             SetDWORD( send_buf, m_pUserData->m_sWarehouseArray[i].nNum, send_index );
             SetShort( send_buf, m_pUserData->m_sWarehouseArray[i].sDuration, send_index );
@@ -4975,7 +4975,7 @@ void CUser::ItemGet(char * pBuf) {
                 SetByte(send_buff, pos, send_index);
                 SetDWORD(send_buff, itemid, send_index);
                 SetShort(send_buff, count, send_index);
-                SetDWORD(send_buff, m_pUserData->m_iGold, send_index);
+                SetInt64(send_buff, m_pUserData->m_iGold, send_index);
                 Send(send_buff, send_index);
             } else {
                 pParty = m_pMain->m_PartyArray.GetData(m_sPartyIndex);
@@ -5008,7 +5008,7 @@ void CUser::ItemGet(char * pBuf) {
                         SetByte(send_buff, 0x02, send_index);
                         SetByte(send_buff, 0xff, send_index); // gold -> pos : 0xff
                         SetDWORD(send_buff, itemid, send_index);
-                        SetDWORD(send_buff, pUser->m_pUserData->m_iGold, send_index);
+                        SetInt64(send_buff, pUser->m_pUserData->m_iGold, send_index);
                         pUser->Send(send_buff, send_index);
                     }
                 }
@@ -5026,7 +5026,7 @@ void CUser::ItemGet(char * pBuf) {
     SetByte(send_buff, pos, send_index);
     SetDWORD(send_buff, itemid, send_index);
     SetShort(send_buff, pGetUser->m_pUserData->m_sItemArray[SLOT_MAX + pos].sCount, send_index);
-    SetDWORD(send_buff, pGetUser->m_pUserData->m_iGold, send_index);
+    SetInt64(send_buff, pGetUser->m_pUserData->m_iGold, send_index);
     pGetUser->Send(send_buff, send_index);
 
     if (m_sPartyIndex != -1) {
@@ -5796,7 +5796,8 @@ void CUser::ExchangeAgree(char * pBuf) {
 }
 
 void CUser::ExchangeAdd(char * pBuf) {
-    int                              index = 0, send_index = 0, count = 0, itemid = 0, duration = 0;
+    int64_t                          count = 0;
+    int                              index = 0, send_index = 0, itemid = 0, duration = 0;
     CUser *                          pUser = NULL;
     _EXCHANGE_ITEM *                 pItem = NULL;
     _ITEM_TABLE *                    pTable = NULL;
@@ -5818,7 +5819,7 @@ void CUser::ExchangeAdd(char * pBuf) {
 
     pos = GetByte(pBuf, index);
     itemid = GetDWORD(pBuf, index);
-    count = GetDWORD(pBuf, index);
+    count = GetInt64(pBuf, index);
     pTable = m_pMain->m_ItemtableArray.GetData(itemid);
     if (!pTable) {
         goto add_fail;
@@ -5903,7 +5904,7 @@ void CUser::ExchangeAdd(char * pBuf) {
     SetByte(buff, WIZ_EXCHANGE, send_index);
     SetByte(buff, EXCHANGE_OTHERADD, send_index);
     SetDWORD(buff, itemid, send_index);
-    SetDWORD(buff, count, send_index);
+    SetInt64(buff, count, send_index);
     SetShort(buff, duration, send_index);
     pUser->Send(buff, send_index);
 
@@ -5972,7 +5973,7 @@ void CUser::ExchangeDecide() {
             SetByte(buff, WIZ_EXCHANGE, send_index);
             SetByte(buff, EXCHANGE_DONE, send_index);
             SetByte(buff, 0x01, send_index);
-            SetDWORD(buff, m_pUserData->m_iGold, send_index);
+            SetInt64(buff, m_pUserData->m_iGold, send_index);
             SetShort(buff, pUser->m_ExchangeItemList.size(), send_index);
             for (Iter = pUser->m_ExchangeItemList.begin(); Iter != pUser->m_ExchangeItemList.end(); Iter++) {
                 SetByte(buff, (*Iter)->pos, send_index); // 새로 들어갈 인벤토리 위치
@@ -5990,7 +5991,7 @@ void CUser::ExchangeDecide() {
             SetByte(buff, WIZ_EXCHANGE, send_index);
             SetByte(buff, EXCHANGE_DONE, send_index);
             SetByte(buff, 0x01, send_index);
-            SetDWORD(buff, pUser->m_pUserData->m_iGold, send_index);
+            SetInt64(buff, pUser->m_pUserData->m_iGold, send_index);
             SetShort(buff, m_ExchangeItemList.size(), send_index);
             for (Iter = m_ExchangeItemList.begin(); Iter != m_ExchangeItemList.end(); Iter++) {
                 SetByte(buff, (*Iter)->pos, send_index); // 새로 들어갈 인벤토리 위치
@@ -7147,14 +7148,14 @@ void CUser::ItemRepair(char * pBuf) {
 
     SetByte(send_buff, WIZ_ITEM_REPAIR, send_index);
     SetByte(send_buff, 0x01, send_index);
-    SetDWORD(send_buff, m_pUserData->m_iGold, send_index);
+    SetInt64(send_buff, m_pUserData->m_iGold, send_index);
     Send(send_buff, send_index);
 
     return;
 fail_return:
     SetByte(send_buff, WIZ_ITEM_REPAIR, send_index);
     SetByte(send_buff, 0x00, send_index);
-    SetDWORD(send_buff, m_pUserData->m_iGold, send_index);
+    SetInt64(send_buff, m_pUserData->m_iGold, send_index);
     Send(send_buff, send_index);
 }
 
@@ -7648,8 +7649,9 @@ void CUser::Type3AreaDuration(float currenttime) {
 }
 
 void CUser::WarehouseProcess(char * pBuf) {
-    int  index = 0, send_index = 0, itemid = 0, srcpos = -1, destpos = -1, page = -1, reference_pos = -1, count = 0;
-    char send_buff[2048];
+    int     index = 0, send_index = 0, itemid = 0, srcpos = -1, destpos = -1, page = -1, reference_pos = -1;
+    int64_t count = 0;
+    char    send_buff[2048];
     memset(send_buff, 0x00, 2048);
     _ITEM_TABLE * pTable = NULL;
     BYTE          command = 0;
@@ -7668,7 +7670,7 @@ void CUser::WarehouseProcess(char * pBuf) {
     if (command == WAREHOUSE_OPEN) {
         SetByte(send_buff, WIZ_WAREHOUSE, send_index);
         SetByte(send_buff, WAREHOUSE_OPEN, send_index);
-        SetDWORD(send_buff, m_pUserData->m_iBank, send_index);
+        SetInt64(send_buff, m_pUserData->m_iBank, send_index);
         for (int i = 0; i < WAREHOUSE_MAX; i++) {
             SetDWORD(send_buff, m_pUserData->m_sWarehouseArray[i].nNum, send_index);
             SetShort(send_buff, m_pUserData->m_sWarehouseArray[i].sDuration, send_index);
@@ -7690,7 +7692,7 @@ void CUser::WarehouseProcess(char * pBuf) {
 
     switch (command) {
     case WAREHOUSE_INPUT:
-        count = GetDWORD(pBuf, index);
+        count = GetInt64(pBuf, index);
         if (itemid == ITEM_GOLD) {
             if (m_pUserData->m_iBank + count > 2100000000) {
                 goto fail_return;
@@ -7750,7 +7752,7 @@ void CUser::WarehouseProcess(char * pBuf) {
                        m_pUserData->m_sWarehouseArray[reference_pos + destpos].sDuration);
         break;
     case WAREHOUSE_OUTPUT:
-        count = GetDWORD(pBuf, index);
+        count = GetInt64(pBuf, index);
 
         if (itemid == ITEM_GOLD) {
             if (m_pUserData->m_iGold + count > 2100000000) {
@@ -11536,3 +11538,4 @@ void CUser::RecvDeleteChar(char * pBuf) {
 
     Send(send_buff, send_index);
 }
+


### PR DESCRIPTION
### Description

This PR attempts to fix the famous issue in this game where coins overflow in the client when the player's coins go above 2,100,000,000.

Note that this is far from complete PR to this issue, as there are other pieces that need to be changed, such as data persistence in the server, as well as schema in the database to alter the gold column to be in the size of 8 bytes. This said, the main focus of this PR is to extend the limit for coins, which will reduce the likelihood an overflow will happen + giving the option in the future to increase the size of coins a player can hold. But for now in order to keep things as in the official game, we'll use more storage for coins, but keep the limit checks for 2,100,000,000.

Note for the reviewer:
This PR is on top of another branch that hasn't been merged yet. Please review the following commits:
- https://github.com/ko4life-net/ko/commit/a454e2953e8ea47e5b692ebed6f71dab6bf3106e
- https://github.com/ko4life-net/ko/commit/7476161aaa9d0905c0673dedb6267448c18cb410