### PR TITLE
Adding fix for item drop UI. This helps when the user switches to a different game procedure.

### DIFF
--- a/src/game/GameProcMain.cpp
+++ b/src/game/GameProcMain.cpp
@@ -252,6 +252,7 @@ void CGameProcMain::ReleaseUIs() {
     m_pUINpcEvent->Release();
     m_pUIItemREDlg->Release();
     m_pUIRepairTooltip->Release();
+    m_pUIDroppedItemDlg->Release();
     m_pUIPartyOrForce->Release();
     m_pUISkillTreeDlg->Release();
     m_pUIInventory->Release();


### PR DESCRIPTION
### Description
Fixes issue where item drop UI will show stay open when switching between game procedures.