### PR TITLE
Only kick it out if it has exceeded the maximum level.

### DIFF
--- a/src/server/Ebenezer/User.cpp
+++ b/src/server/Ebenezer/User.cpp
@@ -2492,7 +2492,7 @@ void CUser::SetDetailData() {
     SetSlotItemValue();
     SetUserAbility();
 
-    if (m_pUserData->m_bLevel >= MAX_LEVEL) {
+    if (m_pUserData->m_bLevel > MAX_LEVEL) {
         Close();
     }
 


### PR DESCRIPTION
This pull request fixes the error that the connection with the server was lost when logging into the character in the character selection screen.

**What you need to do for the problem to occur :**

- Create new character.
- Reach the maximum level in the game.
- Get out of the game
- Login to character again.

When you try to log in, you will be disconnected from the server. 