### PR TITLE
1264 GTD OPD Map Loading

### DIFF
--- a/src/engine/N3Base/N3ShapeMgr.cpp
+++ b/src/engine/N3Base/N3ShapeMgr.cpp
@@ -90,7 +90,12 @@ void CN3ShapeMgr::ReleaseShapes() {
 bool CN3ShapeMgr::Load(HANDLE hFile) {
     DWORD dwRWC;
     int   nL = 0;
-
+    int TempVersion, TempIntStringLength;
+    ReadFile(hFile, &(TempVersion), sizeof(int), &dwRWC, NULL);	// Read the map version
+    ReadFile(hFile, &(TempIntStringLength), sizeof(int), &dwRWC, NULL);	// Read the map name char length
+    CHAR * TempOPDMapNamebuffer = new CHAR[TempIntStringLength / sizeof(char) + 1]{};	// Zero-initialized
+    ReadFile(hFile, TempOPDMapNamebuffer, TempIntStringLength, &dwRWC, NULL);	// Now read it and push it back to the OPDMapName char buffer
+	
     if (false == LoadCollisionData(hFile)) {
         return false;
     }

--- a/src/game/N3Terrain.cpp
+++ b/src/game/N3Terrain.cpp
@@ -389,6 +389,11 @@ bool CN3Terrain::Load(HANDLE hFile) {
     }
 
     DWORD dwRWC;
+    int TempVersion, TempIntStringLength;
+    ReadFile(hFile, &(TempVersion), sizeof(int), &dwRWC, NULL);	// Read the map version
+    ReadFile(hFile, &(TempIntStringLength), sizeof(int), &dwRWC, NULL);	// Read the map name char length
+    CHAR * TempGTDMapNamebuffer = new CHAR[TempIntStringLength / sizeof(char) + 1]{};	// Zero-initialized
+    ReadFile(hFile, TempGTDMapNamebuffer, TempIntStringLength, &dwRWC, NULL);	// Now read it and push it back to the GTDMapName char buffer
     ReadFile(hFile, &(m_ti_MapSize), sizeof(int), &dwRWC, NULL);
     m_pat_MapSize = (m_ti_MapSize - 1) / PATCH_TILE_SIZE;
 


### PR DESCRIPTION
1264 GTD and OPD Map loading.

1. Speaks for itself, or refer to posted image.
2. Copy objects directory from 1264 myko client, and zones directory.
3. Make sure DTEX is copied, and there's 1-2 new river files in misc\river which will be needed and probably misc\sky\ moradon.n3sky.
4. Use the zones.tbl from the zip I posted here and replace the data\zones.tbl.
5. Loading into the game will trigger a ASSERT warning that Moradon.birds can't be found which can be ignored.

[1264 Patch.zip](https://github.com/ko4life-net/ko/files/12186851/1264.Patch.zip)
💔Thank you!


![image](https://github.com/ko4life-net/ko/assets/10597986/fc1a0f43-e2d2-41cb-be72-a92d9908ffb0)
This is currently a draft request so please review.