### PR TITLE
FX Particle Gatherpoint fix

### DIFF
--- a/src/engine/N3Base/N3FXPartParticles.cpp
+++ b/src/engine/N3Base/N3FXPartParticles.cpp
@@ -1287,7 +1287,7 @@ void CN3FXPartParticles::Duplicate(CN3FXPartParticles * pSrc) {
     if (m_dwEmitType == FX_PART_PARTICLE_EMIT_TYPE_SPREAD) {
         m_uEmitCon.fEmitAngle = pSrc->m_uEmitCon.fEmitAngle;
     } else if (m_dwEmitType == FX_PART_PARTICLE_EMIT_TYPE_GATHER) {
-        m_uEmitCon.vGatherPoint = m_uEmitCon.vGatherPoint;
+        m_uEmitCon.vGatherPoint = pSrc->m_uEmitCon.vGatherPoint;
     }
 
     m_vPtEmitDir = pSrc->m_vPtEmitDir;


### PR DESCRIPTION
This fixes the GatherPoint for particles to return to a specific spot, there are 3 types spread gather and none, idk if none is ever used but I do sure know staticnova,1920 heal and some other skills use a GatherPoint. This will fix the Particles from collecting in the terrain instead of towards the char's head (1920 heal).

💔Thank you!
