### PR TITLE
Extract common functionality into N3Utils header.

### DIFF
--- a/src/common/N3Utils.h
+++ b/src/common/N3Utils.h
@@ -1,0 +1,15 @@
+
+#pragma once
+
+#include <string>
+#include <ranges>
+#include <algorithm>
+
+namespace N3 {
+
+static bool iequals(const std::string_view & lhs, const std::string_view & rhs) {
+    auto to_lower{std::ranges::views::transform(::tolower)};
+    return std::ranges::equal(lhs | to_lower, rhs | to_lower);
+}
+
+} // namespace N3

--- a/src/game/KnightOnLine.vcxproj
+++ b/src/game/KnightOnLine.vcxproj
@@ -134,6 +134,7 @@
   <ItemGroup>
     <ClInclude Include="..\common\Implode.h" />
     <ClInclude Include="..\common\JvCryption.h" />
+    <ClInclude Include="..\common\N3Utils.h" />
     <ClInclude Include="..\engine\N3Base\JpegFile.h" />
     <ClInclude Include="..\engine\N3Base\BitMapFile.h" />
     <ClInclude Include="..\engine\N3Base\DFont.h" />

--- a/src/game/KnightOnLine.vcxproj.filters
+++ b/src/game/KnightOnLine.vcxproj.filters
@@ -643,6 +643,9 @@
     <ClInclude Include="UIExitMenu.h">
       <Filter>Procedure - Main\UI</Filter>
     </ClInclude>
+    <ClInclude Include="..\common\N3Utils.h">
+      <Filter>N3Base\Core</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="res\Resource.rc">

--- a/src/game/StdAfx.h
+++ b/src/game/StdAfx.h
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <io.h>
 
+#include "N3Utils.h"
 #include "N3Base/My_3DStruct.h"
 #include "N3Base/N3Log.h"
 
@@ -33,10 +34,3 @@ namespace fs = std::filesystem;
 #else
 #define TRACE(fmt, ...) (void)fmt
 #endif
-
-namespace N3 {
-static bool iequals(const std::string_view & lhs, const std::string_view & rhs) {
-    auto to_lower{std::ranges::views::transform(::tolower)};
-    return std::ranges::equal(lhs | to_lower, rhs | to_lower);
-}
-} // namespace N3

--- a/src/server/AIServer/AIServer.vcxproj
+++ b/src/server/AIServer/AIServer.vcxproj
@@ -166,6 +166,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\common\Implode.h" />
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="CircularBuffer.h" />
     <ClInclude Include="Compress.h" />
     <ClInclude Include="Define.h" />

--- a/src/server/AIServer/AIServer.vcxproj.filters
+++ b/src/server/AIServer/AIServer.vcxproj.filters
@@ -286,6 +286,9 @@
     <ClInclude Include="..\..\common\Implode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\AIServer.ico" />

--- a/src/server/AIServer/StdAfx.h
+++ b/src/server/AIServer/StdAfx.h
@@ -29,6 +29,8 @@
 #include <ranges>
 #include <algorithm>
 
+#include "N3Utils.h"
+
 //#include "Mmsystem.h"
 //#include "Imm.h"
 //#include "N3Base/My_3DStruct.h"
@@ -40,10 +42,3 @@
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
-
-namespace N3 {
-static bool iequals(const std::string_view & lhs, const std::string_view & rhs) {
-    auto to_lower{std::ranges::views::transform(::tolower)};
-    return std::ranges::equal(lhs | to_lower, rhs | to_lower);
-}
-} // namespace N3

--- a/src/server/Aujard/Aujard.vcxproj
+++ b/src/server/Aujard/Aujard.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;__SAMMA;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -91,7 +91,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;__SAMMA;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -129,6 +129,7 @@
     <ResourceCompile Include="Aujard.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="Aujard.h" />
     <ClInclude Include="AujardDlg.h" />
     <ClInclude Include="DBAgent.h" />

--- a/src/server/Aujard/Aujard.vcxproj.filters
+++ b/src/server/Aujard/Aujard.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClInclude Include="STLMap.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\Aujard.ico">

--- a/src/server/Ebenezer/Ebenezer.vcxproj
+++ b/src/server/Ebenezer/Ebenezer.vcxproj
@@ -169,6 +169,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\common\Implode.h" />
     <ClInclude Include="..\..\common\JvCryption.h" />
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="AIPacket.h" />
     <ClInclude Include="AISocket.h" />
     <ClInclude Include="BattleSet.h" />

--- a/src/server/Ebenezer/Ebenezer.vcxproj.filters
+++ b/src/server/Ebenezer/Ebenezer.vcxproj.filters
@@ -305,6 +305,9 @@
     <ClInclude Include="..\..\common\Implode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\Ebenezer.ico">

--- a/src/server/ItemManager/ItemManager.vcxproj
+++ b/src/server/ItemManager/ItemManager.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_3DSERVER;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -91,7 +91,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_3DSERVER;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -128,6 +128,7 @@
     <ResourceCompile Include="ItemManager.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="DBAgent.h" />
     <ClInclude Include="Define.h" />
     <ClInclude Include="ItemManager.h" />

--- a/src/server/ItemManager/ItemManager.vcxproj.filters
+++ b/src/server/ItemManager/ItemManager.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClInclude Include="STLMap.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\ItemManager.ico">

--- a/src/server/LoginServer/LoginServer.vcxproj
+++ b/src/server/LoginServer/LoginServer.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -139,6 +139,7 @@
     <ResourceCompile Include="LoginServer.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="CircularBuffer.h" />
     <ClInclude Include="DBProcess.h" />
     <ClInclude Include="Define.h" />

--- a/src/server/LoginServer/LoginServer.vcxproj.filters
+++ b/src/server/LoginServer/LoginServer.vcxproj.filters
@@ -103,6 +103,9 @@
     <ClInclude Include="VersionSet.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\LoginServer.ico">

--- a/src/tool/KscViewer/KscViewer.vcxproj
+++ b/src/tool/KscViewer/KscViewer.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(VendorDir)\jpeglib\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(VendorDir)\jpeglib\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\jpeglib\include;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\jpeglib\include;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -135,6 +135,7 @@
     <ResourceCompile Include="KscViewer.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\..\engine\N3Base\JpegFile.h" />
     <ClInclude Include="KscViewer.h" />

--- a/src/tool/KscViewer/KscViewer.vcxproj.filters
+++ b/src/tool/KscViewer/KscViewer.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClInclude Include="..\..\engine\N3Base\N3Log.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\KscViewer.ico">

--- a/src/tool/Launcher/Launcher/Launcher.vcxproj
+++ b/src/tool/Launcher/Launcher/Launcher.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -92,7 +92,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(VendorDir)\zlib\include;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -132,6 +132,7 @@
     <ResourceCompile Include="Launcher.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\common\N3Utils.h" />
     <ClInclude Include="APISocket.h" />
     <ClInclude Include="BackgroundUtil.h" />
     <ClInclude Include="BB_CircularBuffer.h" />

--- a/src/tool/Launcher/Launcher/Launcher.vcxproj.filters
+++ b/src/tool/Launcher/Launcher/Launcher.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClInclude Include="StdAfx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\Bkg.bmp">

--- a/src/tool/N3CE/N3CE.vcxproj
+++ b/src/tool/N3CE/N3CE.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -182,6 +182,7 @@
     <ResourceCompile Include="N3CE.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\Widget\PropertyList.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />

--- a/src/tool/N3CE/N3CE.vcxproj.filters
+++ b/src/tool/N3CE/N3CE.vcxproj.filters
@@ -376,6 +376,9 @@
     <ClInclude Include="..\..\engine\N3Base\N3Log.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\N3CE.ico">

--- a/src/tool/N3FXE/N3FXE.vcxproj
+++ b/src/tool/N3FXE/N3FXE.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;DIRECTINPUT_VERSION=0x0800;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;DIRECTINPUT_VERSION=0x0800;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -202,6 +202,7 @@
     <ResourceCompile Include="N3FXE.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />
     <ClInclude Include="..\..\engine\N3Base\DFont.h" />

--- a/src/tool/N3FXE/N3FXE.vcxproj.filters
+++ b/src/tool/N3FXE/N3FXE.vcxproj.filters
@@ -505,6 +505,9 @@
     <ClInclude Include="..\..\engine\N3Base\N3Log.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\N3FXE.ico">

--- a/src/tool/N3Indoor/N3Indoor.vcxproj
+++ b/src/tool/N3Indoor/N3Indoor.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_N3INDOOR;_CRT_SECURE_NO_WARNINGS;DIRECTINPUT_VERSION=0x0800;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_N3INDOOR;_CRT_SECURE_NO_WARNINGS;DIRECTINPUT_VERSION=0x0800;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -145,6 +145,7 @@
     <Text Include="ReadMe.txt" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\Widget\PropertyList.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />

--- a/src/tool/N3Indoor/N3Indoor.vcxproj.filters
+++ b/src/tool/N3Indoor/N3Indoor.vcxproj.filters
@@ -316,6 +316,9 @@
     <ClInclude Include="..\..\engine\N3Base\N3Log.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ComDialog.cpp">

--- a/src/tool/N3Indoor/StdAfx.h
+++ b/src/tool/N3Indoor/StdAfx.h
@@ -28,14 +28,9 @@
 
 namespace fs = std::filesystem;
 
-#include "N3Base/My_3DStruct.h"
+#include "N3Utils.h"
 
-namespace N3 {
-static bool iequals(const std::string_view & lhs, const std::string_view & rhs) {
-    auto to_lower{std::ranges::views::transform(::tolower)};
-    return std::ranges::equal(lhs | to_lower, rhs | to_lower);
-}
-} // namespace N3
+#include "N3Base/My_3DStruct.h"
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/src/tool/N3ME/N3ME.vcxproj
+++ b/src/tool/N3ME/N3ME.vcxproj
@@ -61,7 +61,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_KNIGHT;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -94,7 +94,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>NDEBUG;WIN32;_WINDOWS;_N3TOOL;_KNIGHT;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(SrcDir)\game;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -253,6 +253,7 @@
     <ClCompile Include="WarpMgr.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />
     <ClInclude Include="..\..\engine\N3Base\LogWriter.h" />

--- a/src/tool/N3ME/N3ME.vcxproj.filters
+++ b/src/tool/N3ME/N3ME.vcxproj.filters
@@ -726,6 +726,9 @@
     <ClInclude Include="..\..\engine\N3Base\N3Log.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="N3ME.rc">

--- a/src/tool/N3TexViewer/N3TexViewer.vcxproj
+++ b/src/tool/N3TexViewer/N3TexViewer.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -143,6 +143,7 @@
     <ResourceCompile Include="N3TexViewer.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />
     <ClInclude Include="..\..\engine\N3Base\LogWriter.h" />

--- a/src/tool/N3TexViewer/N3TexViewer.vcxproj.filters
+++ b/src/tool/N3TexViewer/N3TexViewer.vcxproj.filters
@@ -127,6 +127,9 @@
     <ClInclude Include="..\..\engine\N3Base\LogWriter.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\N3TexViewer.ico">

--- a/src/tool/N3TexViewer/StdAfx.h
+++ b/src/tool/N3TexViewer/StdAfx.h
@@ -30,12 +30,5 @@ namespace fs = std::filesystem;
 
 #include "N3Base/My_3DStruct.h"
 
-namespace N3 {
-static bool iequals(const std::string_view & lhs, const std::string_view & rhs) {
-    auto to_lower{std::ranges::views::transform(::tolower)};
-    return std::ranges::equal(lhs | to_lower, rhs | to_lower);
-}
-} // namespace N3
-
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.

--- a/src/tool/N3Viewer/N3Viewer.vcxproj
+++ b/src/tool/N3Viewer/N3Viewer.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -178,6 +178,7 @@
     <ResourceCompile Include="N3Viewer.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\Widget\PropertyList.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />
     <ClInclude Include="..\..\engine\N3Base\My_3DStruct.h" />

--- a/src/tool/N3Viewer/N3Viewer.vcxproj.filters
+++ b/src/tool/N3Viewer/N3Viewer.vcxproj.filters
@@ -340,6 +340,9 @@
     <ClInclude Include="ViewSceneTree.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\N3Viewer.ico">

--- a/src/tool/Option/Option.vcxproj
+++ b/src/tool/Option/Option.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -91,7 +91,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -126,6 +126,7 @@
     <ResourceCompile Include="Option.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="Option.h" />
     <ClInclude Include="OptionDlg.h" />
     <ClInclude Include="Resource.h" />

--- a/src/tool/Option/Option.vcxproj.filters
+++ b/src/tool/Option/Option.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClInclude Include="StdAfx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\Option.ico">

--- a/src/tool/RscTables/RscTables.vcxproj
+++ b/src/tool/RscTables/RscTables.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -91,7 +91,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -129,6 +129,7 @@
     <ResourceCompile Include="RscTables.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\Widget\PropertyList.h" />
     <ClInclude Include="DlgDataCount.h" />
     <ClInclude Include="Resource.h" />

--- a/src/tool/RscTables/RscTables.vcxproj.filters
+++ b/src/tool/RscTables/RscTables.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClInclude Include="TableGenerator.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\RscTables.ico">

--- a/src/tool/ServerInfoViewer/ServerInfoViewer.vcxproj
+++ b/src/tool/ServerInfoViewer/ServerInfoViewer.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -143,6 +143,7 @@
     <ResourceCompile Include="ServerInfoViewer.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\..\engine\N3Base\My_3DStruct.h" />
     <ClInclude Include="..\..\engine\N3Base\My_Macro.h" />

--- a/src/tool/ServerInfoViewer/ServerInfoViewer.vcxproj.filters
+++ b/src/tool/ServerInfoViewer/ServerInfoViewer.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClInclude Include="..\..\engine\N3Base\N3Transform.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\ServerInfoViewer.ico">

--- a/src/tool/SkyViewer/SkyViewer.vcxproj
+++ b/src/tool/SkyViewer/SkyViewer.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -163,6 +163,7 @@
     <ResourceCompile Include="SkyViewer.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\Widget\PropertyList.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />

--- a/src/tool/SkyViewer/SkyViewer.vcxproj.filters
+++ b/src/tool/SkyViewer/SkyViewer.vcxproj.filters
@@ -250,6 +250,9 @@
     <ClInclude Include="..\..\engine\N3Base\N3Log.h">
       <Filter>N3Base</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\SkyViewer.ico">

--- a/src/tool/UIE/UIE.vcxproj
+++ b/src/tool/UIE/UIE.vcxproj
@@ -59,7 +59,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_N3TOOL;_N3UIE;DIRECTINPUT_VERSION=0x0800;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -93,7 +93,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_N3TOOL;_N3UIE;DIRECTINPUT_VERSION=0x0800;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0502;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SrcDir)\common;$(SrcDir)\engine;$(VendorDir)\spdlog\include;$(WindowsSDK_IncludePath);$(VendorDir)\DXSDK9\Include</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4091 /wd4244 /wd4267 /wd4477 /wd4838 /wd6031 /wd26495 /wd4102 %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -169,6 +169,7 @@
     <ResourceCompile Include="UIE.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\common\N3Utils.h" />
     <ClInclude Include="..\Widget\PropertyList.h" />
     <ClInclude Include="..\..\engine\N3Base\N3Log.h" />
     <ClInclude Include="..\..\engine\N3Base\BitMapFile.h" />

--- a/src/tool/UIE/UIE.vcxproj.filters
+++ b/src/tool/UIE/UIE.vcxproj.filters
@@ -301,6 +301,9 @@
     <ClInclude Include="DlgReplace.h">
       <Filter>Dialogs</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\common\N3Utils.h">
+      <Filter>N3Base</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\Toolbar.bmp">


### PR DESCRIPTION
### Description

This PR introduces N3Utils shared header only file in order to reuse simple functions across all projects.
This with the desclaimer that we shouldn't add there things that are not part of the STL (Standard Library), unless all projects are using a thirdparty library, then it makes sense adding it there, but ideally not.

I made this change now, because of the upcoming PRs requires additional shared functions that will be added later and also to make it easier to maintain moving forward.