### PR TITLE
Fix overrun when receiving debug packet (0xFF) in debug builds

### DIFF
--- a/src/game/APISocket.cpp
+++ b/src/game/APISocket.cpp
@@ -143,7 +143,7 @@ void CAPISocket::Release() {
     WriteFile(hFile1, szBuff, lstrlen(szBuff), &dwRWC, NULL);
     WriteFile(hFile2, szBuff, lstrlen(szBuff), &dwRWC, NULL);
 
-    for(int i = 0; i < 255; i++)
+    for(int i = 0; i < UCHAR_MAX + 1; i++)
     {
         if(i == N3_NPC_MOVE) lstrcpy(szCmd, "NPC Move");
         else if(i == N3_ATTACK) lstrcpy(szCmd, "Attack");
@@ -169,10 +169,8 @@ void CAPISocket::Release() {
     }
 */
 
-    for (int i = 0; i < 255; i++) {
-        memset(m_Statistics_Send_Sum, 0, sizeof(m_Statistics_Send_Sum));
-        memset(m_Statistics_Recv_Sum, 0, sizeof(m_Statistics_Recv_Sum));
-    }
+    memset(m_Statistics_Send_Sum, 0, sizeof(m_Statistics_Send_Sum));
+    memset(m_Statistics_Recv_Sum, 0, sizeof(m_Statistics_Recv_Sum));
 
 //    CloseHandle(hFile1);
 //    CloseHandle(hFile2);
@@ -270,10 +268,8 @@ int CAPISocket::Connect(HWND hWnd, const char * pszIP, DWORD dwPort) {
     m_bConnected = TRUE;
 
 #ifdef _DEBUG
-    for (int i = 0; i < 255; i++) {
-        memset(m_Statistics_Send_Sum, 0, sizeof(m_Statistics_Send_Sum));
-        memset(m_Statistics_Recv_Sum, 0, sizeof(m_Statistics_Recv_Sum));
-    }
+    memset(m_Statistics_Send_Sum, 0, sizeof(m_Statistics_Send_Sum));
+    memset(m_Statistics_Recv_Sum, 0, sizeof(m_Statistics_Recv_Sum));
 #endif
 
     return 0;
@@ -415,12 +411,6 @@ void CAPISocket::Send(BYTE * pData, int nSize) {
 
 #ifdef _DEBUG
     BYTE byCmd = pData[0]; // 통계 넣기..
-
-    //    __SocketStatisics SS;
-    //    SS.dwTime = GetTickCount();
-    //    SS.iSize = nSize;
-    //    m_Statistics_Send[byCmd].push_back(SS);
-
     m_Statistics_Send_Sum[byCmd].dwTime++;
     m_Statistics_Send_Sum[byCmd].iSize += nSize;
 #endif

--- a/src/game/APISocket.h
+++ b/src/game/APISocket.h
@@ -229,10 +229,8 @@ class CAPISocket {
     std::queue<DataPack *> m_qRecvPkt;
 
 #ifdef _DEBUG
-    __SocketStatisics m_Statistics_Send_Sum[255];
-    __SocketStatisics m_Statistics_Recv_Sum[255];
-//    std::vector<__SocketStatisics> m_Statistics_Send[255];
-//    std::vector<__SocketStatisics> m_Statistics_Recv[255];
+    __SocketStatisics m_Statistics_Send_Sum[UCHAR_MAX + 1];
+    __SocketStatisics m_Statistics_Recv_Sum[UCHAR_MAX + 1];
 #endif
 
   public:


### PR DESCRIPTION
We raise it to effectively support a total of 256 opcodes instead of 255, as 0~255 inclusive = 256 opcodes, causing it to overrun when sending/receiving the N3_TEMP_TEST packet.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ x Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
This fixes an overrun when receiving the debug packet (N3_TEMP_TEST / 0xFF) in debug builds.
We raise it to effectively support a total of 256 opcodes instead of 255, as 0~255 inclusive = 256 opcodes, which originally caused it to overrun when sending/receiving the N3_TEMP_TEST (0xFF) packet.

💔Thank you!
