### PR TITLE
Fix invalid SQLExecDirect() calls

### DIFF
--- a/src/server/Aujard/DBAgent.cpp
+++ b/src/server/Aujard/DBAgent.cpp
@@ -198,7 +198,7 @@ BOOL CDBAgent::LoadUserData(char * userid, int uid) {
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode == SQL_SUCCESS) { //|| retcode == SQL_SUCCESS_WITH_INFO){
         retcode = SQLFetch(hstmt);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
@@ -535,7 +535,7 @@ int CDBAgent::UpdateUser(const char * userid, int uid, int type) {
         retcode = SQLBindParameter(hstmt, 3, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_BINARY, sizeof(bySerial), 0, bySerial,
                                    0, &sBySerial);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -583,7 +583,7 @@ int CDBAgent::AccountLogInReq(char * id, char * pw) {
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_SMALLINT, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
                 SQLFreeHandle((SQLSMALLINT)SQL_HANDLE_STMT, hstmt);
                 if (sParmRet == 0) {
@@ -627,7 +627,7 @@ BOOL CDBAgent::NationSelect(char * id, int nation) {
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_INTEGER, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -671,7 +671,7 @@ int CDBAgent::CreateNewChar(char * accountid, int index, char * charid, int race
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_INTEGER, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -710,7 +710,7 @@ BOOL CDBAgent::DeleteChar(int index, char * id, char * charid, char * socno) {
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_INTEGER, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -766,7 +766,7 @@ BOOL CDBAgent::LoadCharInfo(char * id, char * buff, int & buff_index) {
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
         retcode = SQLFetch(hstmt);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
@@ -853,7 +853,7 @@ BOOL CDBAgent::GetAllCharID(const char * id, char * char1, char * char2, char * 
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
         retcode = SQLFetch(hstmt);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
@@ -911,7 +911,7 @@ int CDBAgent::CreateKnights(int knightsindex, int nation, char * name, char * ch
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_INTEGER, 0, 0, &sParmRet, 0, &cbParmRet);
         //retcode = SQLBindParameter(hstmt, 2, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_INTEGER, 0,0, &sKnightIndex,0, &cbParmRet );
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -952,7 +952,7 @@ int CDBAgent::UpdateKnights(int type, char * userid, int knightsindex, int domin
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_INTEGER, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -994,7 +994,7 @@ int CDBAgent::DeleteKnights(int knightsindex) {
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_INTEGER, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -1038,7 +1038,7 @@ int CDBAgent::LoadKnightsAllMembers(int knightsindex, int start, char * temp_buf
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_GameDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
             while (bData) {
                 retcode = SQLFetch(hstmt);
@@ -1119,7 +1119,7 @@ BOOL CDBAgent::UpdateConCurrentUserCount(int serverno, int zoneno, int t_count) 
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_AccountDB1.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_ERROR) {
             if (DisplayErrorMsg(hstmt) == -1) {
                 m_AccountDB1.Close();
@@ -1162,7 +1162,7 @@ BOOL CDBAgent::LoadWarehouseData(const char * accountid, int uid) {
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
         retcode = SQLFetch(hstmt);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
@@ -1292,7 +1292,7 @@ int CDBAgent::UpdateWarehouseData(const char * accountid, int uid, int type) {
         retcode = SQLBindParameter(hstmt, 2, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_BINARY, sizeof(bySerial), 0, bySerial,
                                    0, &sBySerial);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_ERROR) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_GameDB.Close();
@@ -1343,7 +1343,7 @@ BOOL CDBAgent::LoadKnightsInfo(int index, char * buff, int & buff_index) {
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_GameDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
             retcode = SQLFetch(hstmt);
             if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
@@ -1412,7 +1412,7 @@ BOOL CDBAgent::SetLogInInfo(const char * accountid, const char * charid, const c
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_AccountDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_ERROR) {
             bSuccess = FALSE;
             if (DisplayErrorMsg(hstmt) == -1) {
@@ -1456,7 +1456,7 @@ int CDBAgent::AccountLogout(const char * accountid) {
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_SMALLINT, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
                 SQLFreeHandle((SQLSMALLINT)SQL_HANDLE_STMT, hstmt);
                 if (sParmRet == 0) {
@@ -1503,7 +1503,7 @@ BOOL CDBAgent::CheckUserData(const char * accountid, const char * charid, int ty
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_GameDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
             retcode = SQLFetch(hstmt);
             if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
@@ -1569,7 +1569,7 @@ void CDBAgent::LoadKnightsAllList(int nation) {
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_GameDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
             while (bData) {
                 retcode = SQLFetch(hstmt);
@@ -1666,7 +1666,7 @@ BOOL CDBAgent::UpdateBattleEvent(const char * charid, int nation) {
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_GameDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_ERROR) {
             if (DisplayErrorMsg(hstmt) == -1) {
                 m_GameDB.Close();
@@ -1709,7 +1709,7 @@ BOOL CDBAgent::CheckCouponEvent(const char * accountid) {
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
         //SQLFreeHandle((SQLSMALLINT)SQL_HANDLE_STMT,hstmt);
         if (sRet == 0) {
@@ -1760,7 +1760,7 @@ BOOL CDBAgent::UpdateCouponEvent(const char * accountid, char * charid, char * c
         return FALSE;
     }    */
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
         //SQLFreeHandle((SQLSMALLINT)SQL_HANDLE_STMT,hstmt);
         retval = TRUE;

--- a/src/server/Ebenezer/KnightsManager.cpp
+++ b/src/server/Ebenezer/KnightsManager.cpp
@@ -1304,7 +1304,7 @@ BOOL CKnightsManager::LoadAllKnights() {
     retcode = SQLAllocHandle( (SQLSMALLINT)SQL_HANDLE_STMT, m_KnightsDB.m_hdbc, &hstmt );
     if (retcode == SQL_SUCCESS)
     {
-        retcode = SQLExecDirect (hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect (hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_SUCCESS|| retcode == SQL_SUCCESS_WITH_INFO) {
             while (bData) {
                 retcode = SQLFetch(hstmt);
@@ -1446,7 +1446,7 @@ BOOL CKnightsManager::LoadKnightsIndex(int index) {
     retcode = SQLAllocHandle( (SQLSMALLINT)SQL_HANDLE_STMT, m_KnightsDB.m_hdbc, &hstmt );
     if (retcode == SQL_SUCCESS)
     {
-        retcode = SQLExecDirect (hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect (hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode == SQL_SUCCESS|| retcode == SQL_SUCCESS_WITH_INFO) {
             retcode = SQLFetch(hstmt);
             if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {

--- a/src/server/LoginServer/DBProcess.cpp
+++ b/src/server/LoginServer/DBProcess.cpp
@@ -85,7 +85,7 @@ BOOL CDBProcess::LoadVersionList() {
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode != SQL_SUCCESS && retcode != SQL_SUCCESS_WITH_INFO) {
         if (DisplayErrorMsg(hstmt) == -1) {
             m_VersionDB.Close();
@@ -155,7 +155,7 @@ int CDBProcess::AccountLogin(const char * id, const char * pwd) {
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_SMALLINT, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode != SQL_SUCCESS && retcode != SQL_SUCCESS_WITH_INFO) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_VersionDB.Close();
@@ -188,7 +188,7 @@ int CDBProcess::MgameLogin(const char * id, const char * pwd) {
         retcode =
             SQLBindParameter(hstmt, 1, SQL_PARAM_OUTPUT, SQL_C_SSHORT, SQL_SMALLINT, 0, 0, &sParmRet, 0, &cbParmRet);
         if (retcode == SQL_SUCCESS) {
-            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+            retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
             if (retcode != SQL_SUCCESS && retcode != SQL_SUCCESS_WITH_INFO) {
                 if (DisplayErrorMsg(hstmt) == -1) {
                     m_VersionDB.Close();
@@ -221,7 +221,7 @@ BOOL CDBProcess::InsertVersion(int version, const char * filename, const char * 
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_VersionDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode != SQL_SUCCESS && retcode != SQL_SUCCESS_WITH_INFO) {
             DisplayErrorMsg(hstmt);
             retvalue = FALSE;
@@ -244,7 +244,7 @@ BOOL CDBProcess::DeleteVersion(const char * filename) {
 
     retcode = SQLAllocHandle((SQLSMALLINT)SQL_HANDLE_STMT, m_VersionDB.m_hdbc, &hstmt);
     if (retcode == SQL_SUCCESS) {
-        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+        retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
         if (retcode != SQL_SUCCESS && retcode != SQL_SUCCESS_WITH_INFO) {
             DisplayErrorMsg(hstmt);
             retvalue = FALSE;
@@ -275,7 +275,7 @@ BOOL CDBProcess::LoadUserCountList() {
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode != SQL_SUCCESS && retcode != SQL_SUCCESS_WITH_INFO) {
         if (DisplayErrorMsg(hstmt) == -1) {
             m_VersionDB.Close();
@@ -325,7 +325,7 @@ BOOL CDBProcess::IsCurrentUser(const char * accountid, char * strServerIP, int &
         return FALSE;
     }
 
-    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, 1024);
+    retcode = SQLExecDirect(hstmt, (unsigned char *)szSQL, SQL_NTS);
     if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {
         retcode = SQLFetch(hstmt);
         if (retcode == SQL_SUCCESS || retcode == SQL_SUCCESS_WITH_INFO) {


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
These should supply the length of the query or SQL_NTS to indicate a null-terminated string, not the entire size of the buffer (https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlexecdirect-function?view=sql-server-ver16).

This only happens to behave 'correctly' in older ANSI drivers by luck; in most cases, modern drivers will report an error with the query which includes the trailing \0 bytes from the buffer.

For simplicity's sake, we can just supply SQL_NTS here and let the driver handle detection. This can be improved later to directly specify the actual length of the string when it's already known, which wsprintf() returns (and is used by most if not all instances).

💔Thank you!
