### PR TITLE
Ensure socket ID list is guarded consistently

### DIFF
--- a/src/server/AIServer/IOCPort.cpp
+++ b/src/server/AIServer/IOCPort.cpp
@@ -44,7 +44,10 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
 
         if (network_event.lNetworkEvents & FD_ACCEPT) {
             if (network_event.iErrorCode[FD_ACCEPT_BIT] == 0) {
+                EnterCriticalSection(&g_critical);
                 sid = pIocport->GetNewSid();
+                LeaveCriticalSection(&g_critical);
+
                 if (sid == -1) {
                     TRACE("Accepting User Socket Fail - New Uid is -1\n");
                     goto loop_pass_accept;
@@ -62,8 +65,11 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
                 len = sizeof(addr);
                 if (!pSocket->Accept(pIocport->m_ListenSocket, (struct sockaddr *)&addr, &len)) {
                     TRACE("Accept Fail %d\n", sid);
+
+                    EnterCriticalSection(&g_critical);
                     pIocport->RidIOCPSocket(sid, pSocket);
                     pIocport->PutOldSid(sid);
+                    LeaveCriticalSection(&g_critical);
                     goto loop_pass_accept;
                 }
 
@@ -71,9 +77,12 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
 
                 if (!pIocport->Associate(pSocket, pIocport->m_hServerIOCPort)) {
                     TRACE("Socket Associate Fail\n");
+
+                    EnterCriticalSection(&g_critical);
                     pSocket->CloseProcess();
                     pIocport->RidIOCPSocket(sid, pSocket);
                     pIocport->PutOldSid(sid);
+                    LeaveCriticalSection(&g_critical);
                     goto loop_pass_accept;
                 }
 

--- a/src/server/Ebenezer/IOCPort.cpp
+++ b/src/server/Ebenezer/IOCPort.cpp
@@ -50,7 +50,10 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
 
         if (network_event.lNetworkEvents & FD_ACCEPT) {
             if (network_event.iErrorCode[FD_ACCEPT_BIT] == 0) {
+                EnterCriticalSection(&g_critical);
                 sid = pIocport->GetNewSid();
+                LeaveCriticalSection(&g_critical);
+
                 if (sid < 0) {
                     TRACE("Accepting User Socket Fail - New Uid is -1\n");
                     char logstr[1024];
@@ -78,8 +81,11 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
                     memset(logstr, NULL, 1024);
                     sprintf(logstr, "Accept Fail %d\r\n", sid);
                     LogFileWrite(logstr);
+
+                    EnterCriticalSection(&g_critical);
                     pIocport->RidIOCPSocket(sid, pSocket);
                     pIocport->PutOldSid(sid);
+                    LeaveCriticalSection(&g_critical);
                     goto loop_pass_accept;
                 }
 
@@ -91,9 +97,12 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
                     memset(logstr, NULL, 1024);
                     sprintf(logstr, "Socket Associate Fail\r\n");
                     LogFileWrite(logstr);
+
+                    EnterCriticalSection(&g_critical);
                     pSocket->CloseProcess();
                     pIocport->RidIOCPSocket(sid, pSocket);
                     pIocport->PutOldSid(sid);
+                    LeaveCriticalSection(&g_critical);
                     goto loop_pass_accept;
                 }
 

--- a/src/server/LoginServer/IOCPort.cpp
+++ b/src/server/LoginServer/IOCPort.cpp
@@ -45,7 +45,10 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
 
         if (network_event.lNetworkEvents & FD_ACCEPT) {
             if (network_event.iErrorCode[FD_ACCEPT_BIT] == 0) {
+                EnterCriticalSection(&g_critical);
                 sid = pIocport->GetNewSid();
+                LeaveCriticalSection(&g_critical);
+
                 if (sid == -1) {
                     TRACE("Accepting User Socket Fail - New Uid is -1\n");
                     goto loop_pass_accept;
@@ -63,8 +66,11 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
                 len = sizeof(addr);
                 if (!pSocket->Accept(pIocport->m_ListenSocket, (struct sockaddr *)&addr, &len)) {
                     TRACE("Accept Fail %d\n", sid);
+
+                    EnterCriticalSection(&g_critical);
                     pIocport->RidIOCPSocket(sid, pSocket);
                     pIocport->PutOldSid(sid);
+                    LeaveCriticalSection(&g_critical);
                     goto loop_pass_accept;
                 }
 
@@ -72,9 +78,12 @@ DWORD WINAPI AcceptThread(LPVOID lp) {
 
                 if (!pIocport->Associate(pSocket, pIocport->m_hServerIOCPort)) {
                     TRACE("Socket Associate Fail\n");
+
+                    EnterCriticalSection(&g_critical);
                     pSocket->CloseProcess();
                     pIocport->RidIOCPSocket(sid, pSocket);
                     pIocport->PutOldSid(sid);
+                    LeaveCriticalSection(&g_critical);
                     goto loop_pass_accept;
                 }
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x]  Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
This prevents race conditions where the ID is removed from the list but not restored (causing a reduced number of available socket IDs in the list), or if especially unlucky, crashes.

The socket ID list is guarded more consistently in ReceiveWorkerThread() implementations, which we essentially follow here.

Ideally I'd have an implementation to better enforce scoping for these, but for consistency with the existing code I just continue to call EnterCriticalSection() & LeaveCriticalSection() manually.

💔Thank you!