### PR TITLE
Bump db version from 1.0.0 to 1.0.2.

### DIFF
--- a/config.cmd
+++ b/config.cmd
@@ -17,7 +17,7 @@ rmdir /s /q %CURRENT_PATH%src\db 2> NUL
 
 git clone --depth=1 https://github.com/ko4life-net/ko-assets %CURRENT_PATH%src\assets
 git clone --depth=1 --branch=1.0.0 https://github.com/ko4life-net/ko-vendor %CURRENT_PATH%src\vendor
-git clone --branch=1.0.0 https://github.com/ko4life-net/ko-db %CURRENT_PATH%src\db
+git clone --branch=1.0.2 https://github.com/ko4life-net/ko-db %CURRENT_PATH%src\db
 
 @REM src\All.sln
 


### PR DESCRIPTION
### Description

Bump db version from 1.0.0 to 1.0.2.

Resolves the following issue: https://github.com/ko4life-net/ko/issues/223
