### PR TITLE
Remove usages of debug libraries from DirectX.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Steve Williams
+Copyright (c) 2024 ko4life-net
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/game/KnightOnLine.vcxproj
+++ b/src/game/KnightOnLine.vcxproj
@@ -71,7 +71,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>imguid.lib;spdlogd.lib;jpegd.lib;d3d9.lib;d3dx9.lib;dsound.lib;ddraw.lib;dxguidd.lib;dinput8d.lib;winmm.lib;imm32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>imguid.lib;spdlogd.lib;jpegd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dinput8.lib;dxguid.lib;ddraw.lib;winmm.lib;imm32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(VendorDir)\imgui\lib;$(VendorDir)\spdlog\lib;$(VendorDir)\jpeglib\lib;$(VendorDir)\DXSDK9\Lib\x86;$(UniversalCRT_LibraryPath_x86)</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
@@ -105,7 +105,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>imgui.lib;spdlog.lib;jpeg.lib;d3d9.lib;d3dx9.lib;dsound.lib;ddraw.lib;dxguid.lib;dinput8.lib;winmm.lib;imm32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>imgui.lib;spdlog.lib;jpeg.lib;d3d9.lib;d3dx9.lib;dsound.lib;dinput8.lib;dxguid.lib;ddraw.lib;winmm.lib;imm32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(VendorDir)\imgui\lib;$(VendorDir)\spdlog\lib;$(VendorDir)\jpeglib\lib;$(VendorDir)\DXSDK9\Lib\x86;</AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/src/server/AIServer/AIServer.vcxproj
+++ b/src/server/AIServer/AIServer.vcxproj
@@ -67,7 +67,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>d3d9.lib;d3dx9.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3dx9.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SrcDir)\common;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
@@ -101,7 +101,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>d3d9.lib;d3dx9.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3dx9.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SrcDir)\common;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/src/server/Ebenezer/Ebenezer.vcxproj
+++ b/src/server/Ebenezer/Ebenezer.vcxproj
@@ -67,7 +67,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>d3d9.lib;d3dx9.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3dx9.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SrcDir)\common;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
@@ -101,7 +101,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>d3d9.lib;d3dx9.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3dx9.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SrcDir)\common;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/src/tool/N3CE/N3CE.vcxproj
+++ b/src/tool/N3CE/N3CE.vcxproj
@@ -67,7 +67,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguidd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(VendorDir)\spdlog\lib;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>

--- a/src/tool/N3FXE/N3FXE.vcxproj
+++ b/src/tool/N3FXE/N3FXE.vcxproj
@@ -67,7 +67,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguidd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(VendorDir)\spdlog\lib;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>

--- a/src/tool/N3Indoor/N3Indoor.vcxproj
+++ b/src/tool/N3Indoor/N3Indoor.vcxproj
@@ -67,7 +67,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguidd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(VendorDir)\spdlog\lib;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>

--- a/src/tool/PlugIn_Max/N3DExp.dsp
+++ b/src/tool/PlugIn_Max/N3DExp.dsp
@@ -80,7 +80,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /debug /machine:I386 /pdbtype:sept
-# ADD LINK32 kernel32.lib user32.lib gdi32.lib comctl32.lib advapi32.lib d3d9.lib d3dx9d.lib dsound.lib dxguidd.lib winmm.lib nafxcwd.lib libcmtd.lib core.lib geom.lib mesh.lib maxutil.lib /nologo /base:"0x105b0000" /subsystem:windows /dll /debug /machine:I386 /out:"debug/N3DExp.dli" /pdbtype:sept
+# ADD LINK32 kernel32.lib user32.lib gdi32.lib comctl32.lib advapi32.lib d3d9.lib d3dx9.lib dsound.lib dxguid.lib winmm.lib nafxcwd.lib libcmtd.lib core.lib geom.lib mesh.lib maxutil.lib /nologo /base:"0x105b0000" /subsystem:windows /dll /debug /machine:I386 /out:"debug/N3DExp.dli" /pdbtype:sept
 # SUBTRACT LINK32 /pdb:none
 # Begin Special Build Tool
 SOURCE="$(InputPath)"

--- a/src/tool/PlugIn_Maya/N3E2.dsp
+++ b/src/tool/PlugIn_Maya/N3E2.dsp
@@ -81,7 +81,7 @@ BSC32=bscmake.exe
 # ADD BSC32 /nologo
 LINK32=link.exe
 # ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:windows /dll /debug /machine:I386 /pdbtype:sept
-# ADD LINK32 d3d9.lib d3dx9d.lib dsound.lib dxguidd.lib winmm.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib nafxcwd.lib /nologo /subsystem:windows /dll /debug /machine:I386 /out:"g:\N3Export2.mll" /pdbtype:sept /libpath:"..\lib" /libpath:"..\..\..\lib" /export:initializePlugin /export:uninitializePlugin
+# ADD LINK32 d3d9.lib d3dx9.lib dsound.lib dxguid.lib winmm.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib nafxcwd.lib /nologo /subsystem:windows /dll /debug /machine:I386 /out:"g:\N3Export2.mll" /pdbtype:sept /libpath:"..\lib" /libpath:"..\..\..\lib" /export:initializePlugin /export:uninitializePlugin
 # SUBTRACT LINK32 /pdb:none /nodefaultlib
 
 !ENDIF 

--- a/src/tool/PlugIn_Maya/N3E2.mak
+++ b/src/tool/PlugIn_Maya/N3E2.mak
@@ -375,7 +375,7 @@ BSC32_SBRS= \
 <<
 
 LINK32=link.exe
-LINK32_FLAGS=d3d9.lib d3dx9d.lib dsound.lib dxguidd.lib winmm.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib nafxcwd.lib /nologo /subsystem:windows /dll /incremental:yes /pdb:"$(OUTDIR)\N3Export2.pdb" /debug /machine:I386 /out:"g:\N3Export2.mll" /implib:"$(OUTDIR)\N3Export2.lib" /pdbtype:sept /libpath:"..\lib" /libpath:"..\..\..\lib" /export:initializePlugin /export:uninitializePlugin 
+LINK32_FLAGS=d3d9.lib d3dx9.lib dsound.lib dxguid.lib winmm.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib nafxcwd.lib /nologo /subsystem:windows /dll /incremental:yes /pdb:"$(OUTDIR)\N3Export2.pdb" /debug /machine:I386 /out:"g:\N3Export2.mll" /implib:"$(OUTDIR)\N3Export2.lib" /pdbtype:sept /libpath:"..\lib" /libpath:"..\..\..\lib" /export:initializePlugin /export:uninitializePlugin 
 LINK32_OBJS= \
 	"$(INTDIR)\BitMapFile.obj" \
 	"$(INTDIR)\iffreader.obj" \

--- a/src/tool/UIE/UIE.vcxproj
+++ b/src/tool/UIE/UIE.vcxproj
@@ -67,7 +67,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguidd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>spdlogd.lib;d3d9.lib;d3dx9.lib;dsound.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(VendorDir)\spdlog\lib;$(VendorDir)\DXSDK9\Lib\x86</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>


### PR DESCRIPTION
### Description

Note that we're not needing to debug DirectX and there are better ways with today's tooling to debug graphics in general. Also the actual June 2010 SDK is inconsistent and some libraries contain symbols and some don't.

This also helps reducing the size a bit of ko-vendor for the portable DirectX SDK we have there :)

Additionally removed unused usages of d3d9.lib from AIServer and Ebenezer. That's how they had it officially, but these are anyway not being used, since the server don't do graphics, rather just using the math library from d3dx9.lib.
