### PR TITLE
Update docs and execution policy for user.

### DIFF
--- a/config.cmd
+++ b/config.cmd
@@ -1,8 +1,10 @@
-@REM Script for noobs that have hard time reading instructions.
 @echo off
 
 echo Configuring started...
 set CURRENT_PATH=%~dp0
+
+echo Allowing current user to run powershell scripts...
+powershell -command "Set-ExecutionPolicy Bypass -Scope CurrentUser"
 
 where /q git
 if ERRORLEVEL 1 (
@@ -27,8 +29,8 @@ echo Configuring done.
 echo:
 echo You may want to to start the src\All.sln Visual Studio solution to start developing.
 echo:
-echo If you haven't setup the database just yet, one last manual step is needed (assuming you have any version of Microsoft SQL Server installed):
-echo   - Run the powershell script under src\db\import.ps1 to create and import the database into your SQL server.
+echo If you haven't setup the database just yet, one last manual step is needed (assuming you have any version of Microsoft SQL Server installed).
+echo Run the powershell script under src\db\import.ps1 to setup the database for you.
 echo:
 echo:
 echo Thank you and happy coding!

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,39 +2,41 @@
 
 This is the official Knight Online repository containing sources for the game, server and tools.
 
-To get started, clone this repo:
+This is the main project which focuses only on source development. Its corresponding submodules are fetched automatically via the `config.cmd` script and maintained under the following projects:
+- [Database development](https://github.com/ko4life-net/ko-db)
+- [Client assets](https://github.com/ko4life-net/ko-assets)
+- [Portable SDKs and utils](https://github.com/ko4life-net/ko-vendor)
+
+
+
+### Prerequisite
+
+- Visual Studio 2022: The project may be built with older Visual Studio versions, however for the sake of consistency, please install Visual Studio 2022.
+You will also need to install additional MSVC, MFC and ATL components if you haven't already. The way it's done in Visual Studio 2022 is by:
+  - Click on `Tool` -> `Get Tools and Features...`
+  - In the new window switch to `Individual components` tab
+  - Search for `mfc` and select `C++ MFC for latest v143 build tools (x86 & x64)`
+  - Search for `atl` and select `C++ ATL for latest v143 build tools (x86 & x64)`
+  - Search for `msvc` and select `MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)`
+  - Click on `Modify` to start the installation
+- Microsoft SQL Server Express or Developer (confirmed to be working with 2008 and 2022)
+  - SQL Server: https://www.microsoft.com/en-us/sql-server/sql-server-downloads
+  - SQL Management Studio: https://learn.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms
+- Git: https://git-scm.com/download/win
+
+
+### Getting Started
+
+To get started, clone this repository:
 ```
 git clone https://github.com/ko4life-net/ko.git
 ```
-and then double click to the `config.cmd` script in the root directory to fetch external dependencies.
+and then double click on the `config.cmd` script in the root directory.
 
-The project may be built with older Visual Studio versions, however for the sake of consistency, please install Visual Studio 2022.
-You will also need to install additional MSVC, MFC and ATL components if you haven't already. The way it's done in Visual Studio 2022 is by:
-- Click on `Tool` -> `Get Tools and Features...`
-- In the new window switch to `Individual components` tab
-- Search for `mfc` and select `C++ MFC for latest v143 build tools (x86 & x64)`
-- Search for `atl` and select `C++ ATL for latest v143 build tools (x86 & x64)`
-- Search for `msvc` and select `MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)`
-- Click on `Modify` to start the installation
+After configuring the project is done, you can now start the Visual Studio solution (`*.sln`) file of your preference under the src directory.
 
-Note that the entire project has been updated to DirectX-9. There are some runtime dlls that are needed in your system. That being said, if you don't have DirectX-9 already installed in your system and you getting error while trying to open either the game or tools similar to this: `d3dx9d_43.dll is missing`, then you need to install the redistributable runtime dlls. I zipped it from the SDK in case you having troubles: `DX9_Redist.zip` and you can download it from the Releases in GitHub. Unzip and simply run the `SETUP.exe`.
 
-## Setting up the database
-
-The database project is built via SQL scripts. The repository where the database is hosted can be found here: https://github.com/ko4life-net/ko-db
-
-In order to setup the database, run the `import.ps1` powershell script by right clicking it and `Run with Powershell`.
-
-Note that if you haven't installed MSSQL with default instance, you may want to adjust the variable `$server_name` in the import script as your instance server name.
-
-The import should run and setup the login and username, as well as permissions for `db_owner`:
-- DSN: `kodb`
-- UID: `kodb_user`
-- PWD: `kodb_user`
-
-Lastly you'll need to setup odbcad settings so that the server can access the database with the odbcad driver.
-
-# Code formatting / Linting
+### Code formatting / Linting
 
 This project is using clang-format from LLVM project to ensure consistency in the entire codebase and to make it easier for everyone to contribute.
 


### PR DESCRIPTION
### Description

This PR updates docs and execution policy for current user, so that they can run powershell scripts on a freshly installed system.

Note that the reason for the execution policy change is because many users follow the steps and then they trying to run the powershell scripts, mainly in the database project, and don't understand why it is not working. Anyway a development machine needs to run scripts, so there is no need to restrict it in first place.

The cool thing is because we're setting it for the current user, there is no need for admin rights to enable it. Thanks to @xGuTeK for this advice.
