### PR TITLE
Fixes the border width of the game

### DIFF
--- a/src/game/Main.cpp
+++ b/src/game/Main.cpp
@@ -249,7 +249,7 @@ HWND CreateMainWindow(HINSTANCE hInstance) {
         rect.right = iWidth;
         AdjustWindowRect(&rect, dwStyle, FALSE);
         iHeight = rect.bottom + GetSystemMetrics(SM_CYCAPTION);
-        iWidth = rect.right;
+        iWidth = rect.right + GetSystemMetrics(SM_CXFRAME)+4;
     }
 
     return ::CreateWindow("Knight OnLine Client", "Knight OnLine Client", dwStyle, 0, 0, iWidth, iHeight, NULL, NULL,


### PR DESCRIPTION
Fixes the border width of the game

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

### Description
Fixes the border width of the game where normally turning camera is captured outside of the frame and skill icons are cut off

💔Thank you!
![image](https://github.com/user-attachments/assets/a8442ee4-3ff3-45cc-a96a-7756ac2fcb5e)
