### PR TITLE
Overlapped texts fix UISkillTreeDlg.cpp

### DIFF
--- a/src/game/UISkillTreeDlg.cpp
+++ b/src/game/UISkillTreeDlg.cpp
@@ -1617,7 +1617,7 @@ void CUISkillTreeDlg::AllClearImageByName(const std::string & szFN, bool bTrueOr
     CN3UIBase *   pBase = NULL;
     CN3UIButton * pButton = NULL;
     for (int i = 0; i < 4; i++) {
-        pBase = GetChildBaseByName(std::format("img_{}{}", szFN, i));
+        pBase = GetChildBaseByName(std::format("img_{}_{}", szFN, i));
         if (pBase) {
             pBase->SetVisible(bTrueOrNot);
         }


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

### Description
This fixes the overlapping texts of the following strings: "img_class_1-3".
Result:
![image](https://github.com/user-attachments/assets/85013ac9-a79a-4498-a564-b616599e09f3)
Before:
![image](https://github.com/user-attachments/assets/7d5c4879-398a-4b2a-b0ed-789de9ab1b3f)


💔Thank you!
