### PR TITLE
Set projects' working directories to use the current path.

### DIFF
--- a/src/game/Main.cpp
+++ b/src/game/Main.cpp
@@ -314,9 +314,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
     // 스피드 핵 체킹용...
     //////////////////////////////
 
-    char szPath[_MAX_PATH] = "";
-    GetCurrentDirectory(_MAX_PATH, szPath);
-    CN3Base::PathSet(szPath);
+    CN3Base::PathSet(fs::current_path().string());
 
     // 세팅 읽기..
     char szIniPath[_MAX_PATH] = "";

--- a/src/tool/N3CE/MainFrm.cpp
+++ b/src/tool/N3CE/MainFrm.cpp
@@ -71,6 +71,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     EnableDocking(CBRS_ALIGN_ANY);
     DockControlBar(&m_wndToolBar);
 
+    CN3Base::PathSet(fs::current_path().string());
+
     // Engine 생성
     //    m_Eng.InitEnv();
     if (m_Eng.Init(TRUE, m_hWnd, 64, 64, 0, TRUE) == false) {

--- a/src/tool/N3FXE/MainFrm.cpp
+++ b/src/tool/N3FXE/MainFrm.cpp
@@ -163,6 +163,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     // TODO: Remove this if you don't want tool tips
     m_wndToolBar.SetBarStyle(m_wndToolBar.GetBarStyle() | CBRS_TOOLTIPS | CBRS_FLYBY);
 
+    CN3Base::PathSet(fs::current_path().string());
+
     // Engine 생성
     if (m_Eng.Init(TRUE, m_hWnd, 64, 64, 0, TRUE) == false) {
         return -1;

--- a/src/tool/N3Indoor/MainFrm.cpp
+++ b/src/tool/N3Indoor/MainFrm.cpp
@@ -107,6 +107,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
         return -1; // fail to create
     }
 
+    CN3Base::PathSet(fs::current_path().string());
+
     if (m_Eng.Init(TRUE, m_hWnd, 64, 64, 0, TRUE) == false) {
         return 0;
     }

--- a/src/tool/N3ME/MainFrm.cpp
+++ b/src/tool/N3ME/MainFrm.cpp
@@ -196,10 +196,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     // TODO: Remove this if you don't want tool tips
     m_wndToolBar.SetBarStyle(m_wndToolBar.GetBarStyle() | CBRS_TOOLTIPS | CBRS_FLYBY);
 
-    // 경로 설정..
-    char szPathCur[256] = "";
-    GetCurrentDirectory(256, szPathCur);
-    CN3Base::PathSet(szPathCur);
+    CN3Base::PathSet(fs::current_path().string());
 
     // 엔진 초기화
     m_pEng = new CN3EngTool();

--- a/src/tool/N3TexViewer/MainFrm.cpp
+++ b/src/tool/N3TexViewer/MainFrm.cpp
@@ -77,6 +77,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     EnableDocking(CBRS_ALIGN_ANY);
     DockControlBar(&m_wndToolBar);
 
+    CN3Base::PathSet(fs::current_path().string());
+
     if (m_Eng.Init(TRUE, m_hWnd, 64, 64, 0, TRUE) == false) {
         return -1;
     }

--- a/src/tool/N3Viewer/MainFrm.cpp
+++ b/src/tool/N3Viewer/MainFrm.cpp
@@ -80,6 +80,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     EnableDocking(CBRS_ALIGN_ANY);
     DockControlBar(&m_wndToolBar);
 
+    CN3Base::PathSet(fs::current_path().string());
+
     // Engine 생성
     //    m_Eng.InitEnv();
     if (!m_Eng.Init(TRUE, m_hWnd, 64, 64, 0, TRUE)) {

--- a/src/tool/ServerInfoViewer/MainFrm.cpp
+++ b/src/tool/ServerInfoViewer/MainFrm.cpp
@@ -65,6 +65,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     EnableDocking(CBRS_ALIGN_ANY);
     DockControlBar(&m_wndToolBar);
 
+    CN3Base::PathSet(fs::current_path().string());
+
     m_Camera.EyePosSet(100, 50, -100);
     m_Camera.UpVectorSet(0, 1, 0);
     m_Camera.m_Data.fNP = 1.0f;

--- a/src/tool/SkyViewer/MainFrm.cpp
+++ b/src/tool/SkyViewer/MainFrm.cpp
@@ -62,6 +62,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     EnableDocking(CBRS_ALIGN_ANY);
     DockControlBar(&m_wndToolBar);
 
+    CN3Base::PathSet(fs::current_path().string());
+
     if (!m_Eng.Init(TRUE, m_hWnd, 64, 64, 0, TRUE)) {
         return -1;
     }

--- a/src/tool/UIE/MainFrm.cpp
+++ b/src/tool/UIE/MainFrm.cpp
@@ -87,31 +87,26 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {
     // TODO: Remove this if you don't want tool tips
     m_wndToolBar.SetBarStyle(m_wndToolBar.GetBarStyle() | CBRS_TOOLTIPS | CBRS_FLYBY);
 
+    // Set working directory
+    CWinApp * pApp = AfxGetApp();
+    ASSERT(pApp);
+    CString szRet = pApp->GetProfileString("Work", "Path", "empty");
+    if (szRet == "empty") {
+        char szPath[_MAX_PATH]{};
+        GetModuleFileName(NULL, szPath, _MAX_PATH);
+        std::string szDir = fs::path(szPath).parent_path().string();
+        pApp->WriteProfileString("Work", "Path", szDir.c_str());
+        SetBasePath(szDir.c_str());
+    } else {
+        SetBasePath(szRet);
+    }
+
     // Engine 생성
     //m_Eng.InitEnv();
     if (!m_Eng.Init(TRUE, GetRightPane()->m_hWnd, 64, 64, 0, TRUE)) {
         return -1;
     }
     m_Eng.s_SndMgr.Init(m_hWnd);
-
-    char szPath[_MAX_PATH];
-    char szDrive[_MAX_DRIVE];
-    char szDir[_MAX_DIR];
-    GetModuleFileName(NULL, szPath, _MAX_PATH);
-    _splitpath(szPath, szDrive, szDir, NULL, NULL);
-    _makepath(szPath, szDrive, szDir, NULL, NULL);
-    //    SetCurrentDirectory(szPath);
-    //    SetBasePath(szPath);
-
-    CWinApp * pApp = AfxGetApp();
-    ASSERT(pApp);
-    CString szRet = pApp->GetProfileString("Work", "Path", "empty");
-    if (szRet == "empty") {
-        pApp->WriteProfileString("Work", "Path", szPath);
-        SetBasePath(szPath);
-    } else {
-        SetBasePath(szRet);
-    }
 
     return 0;
 }


### PR DESCRIPTION
### Description

This pull request updates projects' to set the working directory to the current path, enhancing portability and consistency in asset loading.

- Configures projects to load assets relative to the current path, making applications more portable.
- Replaces `GetCurrentDirectory` (WinAPI) with `std::filesystem::current_path` in several instances to simplify code and leverage standard library functionality.