### PR TITLE
Ensure correct handling of null-termination in N3ME string writing.

### DIFF
--- a/src/engine/N3Base/N3River2.cpp
+++ b/src/engine/N3Base/N3River2.cpp
@@ -291,10 +291,9 @@ void CN3River2::Init(const std::string & TexPath) {
         return;
     }
 
-    char szFileName[30];
     for (int i = 0; i < MAX_RIVER_TEX; i++) {
-        sprintf(szFileName, "misc\\river\\caust%02d.dxt", i);
-        m_pTexRiver[i] = s_MngTex.Get(szFileName);
+        fs::path fsTexFile = fs::path("Misc") / "river" / std::format("caust{:02d}.dxt", i);
+        m_pTexRiver[i] = s_MngTex.Get(fsTexFile.string());
         __ASSERT(m_pTexRiver[i], "CN3River2::texture load failed");
     }
     m_pTexWave = s_MngTex.Get(TexPath);


### PR DESCRIPTION
### Description

This pull request addresses an official bug in N3ME by ensuring that the null-termination byte is correctly included when writing strings to files. This fix resolves issues caused by incorrect string length calculations, which previously led to inconsistencies during file operations.
This issue, present in official maps from the 2xxx versions, could lead to confusion or errors for users interpreting these formats.
  
#### Root Cause
The root cause of this bug lies in the process of reading strings from files. Specifically:
- Strings are read with 4 bytes for the string length, followed by the string content.
- If the null-termination byte is read directly into a dynamically allocated container, it becomes part of the string data, leading to failed comparisons despite visible string equality.

#### Compatibility Note
To remain compatible with official formats, we must include the null-termination byte, even though it adds redundancy.

#### Why the Bug Was Overlooked
This issue went unnoticed because the client reads the string into a `char buffer[len]`, then constructs an `std::string` from it. Although the binary format includes the redundant null byte, `std::string` stops at the first null-termination, so the extra byte remained hidden. This effectively made the binary format’s string length 1 byte longer than necessary.