### PR TITLE
Improve N3TexViewer usability: show file path and disable auto-resizing on navigation.

### DIFF
--- a/src/tool/N3TexViewer/MainFrm.cpp
+++ b/src/tool/N3TexViewer/MainFrm.cpp
@@ -521,7 +521,7 @@ void CMainFrame::OnFileOpenNext() {
     if (pDoc) {
         pDoc->OpenNextFile();
     }
-    AdjustWindowSize();
+    //AdjustWindowSize();
 }
 
 void CMainFrame::OnFileOpenPrev() {
@@ -529,7 +529,7 @@ void CMainFrame::OnFileOpenPrev() {
     if (pDoc) {
         pDoc->OpenPrevFile();
     }
-    AdjustWindowSize();
+    //AdjustWindowSize();
 }
 
 void CMainFrame::OnFileOpenFirst() {
@@ -537,7 +537,7 @@ void CMainFrame::OnFileOpenFirst() {
     if (pDoc) {
         pDoc->OpenFirstFile();
     }
-    AdjustWindowSize();
+    //AdjustWindowSize();
 }
 
 void CMainFrame::OnFileOpenLast() {
@@ -545,7 +545,7 @@ void CMainFrame::OnFileOpenLast() {
     if (pDoc) {
         pDoc->OpenLastFile();
     }
-    AdjustWindowSize();
+    //AdjustWindowSize();
 }
 
 void CMainFrame::OnToolSaveRepeat() {

--- a/src/tool/N3TexViewer/N3TexViewerDoc.cpp
+++ b/src/tool/N3TexViewer/N3TexViewerDoc.cpp
@@ -130,6 +130,14 @@ BOOL CN3TexViewerDoc::OnOpenDocument(LPCTSTR lpszPathName) {
     szFileName += szExt;
 
     this->SetTitle(szFileName);
+
+    // Update status bar with the currently opened file path
+    CFrameWnd * pFrm = (CFrameWnd *)AfxGetMainWnd();
+    ASSERT(pFrm);
+    CStatusBar * pSB = (CStatusBar *)pFrm->GetMessageBar();
+    ASSERT(pSB);
+    pSB->SetPaneText(0, lpszPathName);
+
     this->UpdateAllViews(NULL);
 
     return TRUE;


### PR DESCRIPTION
### Description

This pull request enhances the usability of N3TexViewer by displaying the absolute file path of the currently opened texture in the status bar and by disabling automatic window resizing when navigating between textures. These changes improve both visibility and consistency, providing a smoother experience when working with textures.

#### Details

- **Display Absolute File Path**: The status bar now shows the full path of the currently opened texture, making it easier to identify the loaded file’s location without external references.

- **Disable AdjustWindowSize on Navigation**: Previously, the window resized automatically when navigating textures with PageDown and PageUp shortcuts. This behavior often disrupted the user experience, especially with small textures (e.g., 32x32), as it shrank the window to an inconvenient size. Now, the window only adjusts size for the initial texture load, remaining consistent during navigation.