### PR TITLE
Wordwrapping fix

### DIFF
--- a/src/engine/N3Base/N3UIString.cpp
+++ b/src/engine/N3Base/N3UIString.cpp
@@ -493,7 +493,7 @@ int64_t CN3UIString::GetStringAsInt(const std::vector<char> & remove /* = {}*/) 
 
 int CN3UIString::GetStringRealWidth(int iNum) {
     SIZE size{};
-    BOOL bFlag = m_pDFont->GetTextExtent("Arial", lstrlen("Arial"), &size);
+    BOOL bFlag = m_pDFont->GetTextExtent("가", lstrlen("가"), &size);
     __ASSERT(bFlag, "cannot get size of dfont");
     int iLength = iNum / 2;
     if (iLength == 0) {
@@ -504,7 +504,7 @@ int CN3UIString::GetStringRealWidth(int iNum) {
 
 int CN3UIString::GetStringRealWidthRect() {
     SIZE size{};
-    BOOL bFlag = m_pDFont->GetTextExtent("Arial", lstrlen("Arial"), &size);
+    BOOL bFlag = m_pDFont->GetTextExtent("가", lstrlen("가"), &size);
     __ASSERT(bFlag, "cannot get size of dfont");
 
     return (size.cy > 0) ? (m_rcRegion.bottom - m_rcRegion.top) / size.cy : 0;


### PR DESCRIPTION
### Description
English words are made up of multiple 1-byte characters, and they need to be wrapped by word, not by characters.

The current logic wraps whenever the accumulated character width exceeds the region width — no regard for spaces or full words.

This leads to words being split awkwardly in the middle. Implemented word wrapping instead of character wrapping, replaced garbage like "±¼¸²" with Arial.

### 🚨 Checklist for this Pull Request
- [ ] https://github.com/ko4life-net/ko/issues/143
