### PR TITLE
Add functionality to load warp list from database

### DIFF
--- a/src/server/Ebenezer/Ebenezer.vcxproj
+++ b/src/server/Ebenezer/Ebenezer.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -166,6 +166,7 @@
     </ClCompile>
     <ClCompile Include="UdpSocket.cpp" />
     <ClCompile Include="User.cpp" />
+    <ClCompile Include="WarpInfoSet.cpp" />
     <ClCompile Include="ZoneInfoSet.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -220,6 +221,7 @@
     <ClInclude Include="STLMap.h" />
     <ClInclude Include="UdpSocket.h" />
     <ClInclude Include="User.h" />
+    <ClInclude Include="WarpInfoSet.h" />
     <ClInclude Include="ZoneInfoSet.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/server/Ebenezer/Map.h
+++ b/src/server/Ebenezer/Map.h
@@ -39,6 +39,7 @@ class C3DMap {
     float m_fUnitDist; // i Grid Distance
                        //
     void            LoadWarpList(HANDLE hFile);
+    BOOL            LoadWarpListDB(int m_nZoneNumber);
     void            LoadRegeneEvent(HANDLE hFile);
     BOOL            IsValidPosition(float x, float z, float y);
     _OBJECT_EVENT * GetObjectEvent(int objectindex) { return m_ObjectEventArray.GetData(objectindex); };

--- a/src/server/Ebenezer/WarpInfoSet.cpp
+++ b/src/server/Ebenezer/WarpInfoSet.cpp
@@ -1,0 +1,85 @@
+// WarpInfoSet.cpp : implementation file
+//
+
+#include "StdAfx.h"
+#include "WarpInfoSet.h"
+#include "EbenezerDlg.h"
+
+#ifdef _DEBUG
+#define new DEBUG_NEW
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+// CWarpInfoSet
+
+IMPLEMENT_DYNAMIC(CWarpInfoSet, CRecordset)
+
+CWarpInfoSet::CWarpInfoSet(CDatabase * pdb /*=nullptr*/)
+    : CRecordset(pdb) {
+    //{{AFX_FIELD_INIT(CWarpInfoSet)
+    m_iZoneNo = 0;
+    m_sWarpID = 0;
+    m_strWarpName = _T("");
+    m_strAnnounce = _T("");
+    m_dwPay = 0;
+    m_sZone = 0;
+    m_fX = 0.0;
+    m_fY = 0.0;
+    m_fZ = 0.0;
+    m_fR = 0.0;
+    m_nFields = 10; // Number of fields mapped in DoFieldExchange
+    //}}AFX_FIELD_INIT
+    m_nDefaultType = snapshot;
+}
+
+CString CWarpInfoSet::GetDefaultConnect() {
+    return CEbenezerDlg::GetInstance()->GetGameDBConnectionString();
+}
+
+CString CWarpInfoSet::GetDefaultSQL() {
+    return _T("[dbo].[K_WARP_INFO]");
+}
+
+void CWarpInfoSet::DoFieldExchange(CFieldExchange * pFX) {
+    //{{AFX_FIELD_MAP(CWarpInfoSet)
+    pFX->SetFieldType(CFieldExchange::outputColumn);
+    RFX_Int(pFX, _T("ZoneNo"), m_iZoneNo);
+    RFX_Int(pFX, _T("strWarpID"), m_sWarpID);
+    RFX_Text(pFX, _T("strWarpName"), m_strWarpName);
+    RFX_Text(pFX, _T("strAnnounce"), m_strAnnounce);
+    RFX_Long(pFX, _T("dwPay"), m_dwPay);
+    RFX_Int(pFX, _T("sZone"), m_sZone);
+    RFX_Double(pFX, _T("fX"), m_fX);
+    RFX_Double(pFX, _T("fY"), m_fY);
+    RFX_Double(pFX, _T("fZ"), m_fZ);
+    RFX_Double(pFX, _T("fR"), m_fR);
+    //}}AFX_FIELD_MAP
+}
+
+#ifdef _DEBUG
+void CWarpInfoSet::AssertValid() const {
+    CRecordset::AssertValid();
+}
+
+void CWarpInfoSet::Dump(CDumpContext & dc) const {
+    CRecordset::Dump(dc);
+}
+#endif
+
+BOOL CWarpInfoSet::OpenByZoneId(int iZoneNo) {
+    CString strSQL;
+    strSQL.Format(
+        _T("SELECT k.ZoneNo, k.strWarpID, k.strWarpName, k.strAnnounce, k.dwPay, k.sZone, k.fX, k.fY, k.fZ, k.fR ")
+        _T("FROM [dbo].[K_WARP_INFO] k ")
+        _T("INNER JOIN ZONE_INFO zi ON zi.ZoneNo = k.sZone ")
+        _T("WHERE k.ZoneNo = %d"),
+        iZoneNo);
+
+    if (!Open(m_nDefaultType, strSQL, CRecordset::readOnly)) {
+        AfxMessageBox(_T("CWarpInfoSet::OpenByZoneId failed to open recordset"));
+        return FALSE;
+    }
+    return TRUE;
+}

--- a/src/server/Ebenezer/WarpInfoSet.h
+++ b/src/server/Ebenezer/WarpInfoSet.h
@@ -1,0 +1,43 @@
+// WarpInfoSet.h : header file
+//
+
+#pragma once
+
+/////////////////////////////////////////////////////////////////////////////
+// CWarpInfoSet recordset
+
+class CWarpInfoSet : public CRecordset {
+  public:
+    CWarpInfoSet(CDatabase * pDatabase = nullptr);
+    DECLARE_DYNAMIC(CWarpInfoSet)
+
+    // Field/Param Data
+    //{{AFX_FIELD(CWarpInfoSet, CRecordset)
+    int     m_iZoneNo;
+    int     m_sWarpID;
+    CString m_strWarpName;
+    CString m_strAnnounce;
+    long    m_dwPay;
+    int     m_sZone;
+    double  m_fX;
+    double  m_fY;
+    double  m_fZ;
+    double  m_fR;
+    //}}AFX_FIELD
+
+    // Overrides
+    // ClassWizard generated virtual function overrides
+    //{{AFX_VIRTUAL(CWarpInfoSet)
+  public:
+    virtual CString GetDefaultConnect();
+    virtual CString GetDefaultSQL();
+    virtual void    DoFieldExchange(CFieldExchange * pFX);
+    //}}AFX_VIRTUAL
+
+    BOOL OpenByZoneId(int iZoneNo);
+
+#ifdef _DEBUG
+    virtual void AssertValid() const;
+    virtual void Dump(CDumpContext & dc) const;
+#endif
+};


### PR DESCRIPTION
### Description

This change replaces the previous method of loading warp information from SMD files with a new approach that retrieves warp data directly from the database. 
https://github.com/ko4life-net/ko/issues/262

⚠️ This PR also requires changes to the database, such as adding a new table for storing warp information.

💔 Thank you!
