### PR TITLE
Client window size fix

### DIFF
--- a/src/game/Main.cpp
+++ b/src/game/Main.cpp
@@ -247,9 +247,11 @@ HWND CreateMainWindow(HINSTANCE hInstance) {
         RECT rect{};
         rect.bottom = iHeight;
         rect.right = iWidth;
-        AdjustWindowRect(&rect, dwStyle, FALSE);
-        iHeight = rect.bottom + GetSystemMetrics(SM_CYCAPTION);
-        iWidth = rect.right;
+        if (!AdjustWindowRect(&rect, dwStyle, FALSE)) {
+            CLogWriter::Write("AdjustWindowRect failed.");
+        }
+        iWidth = rect.right - rect.left;
+        iHeight = rect.bottom - rect.top;
     }
 
     return ::CreateWindow("Knight OnLine Client", "Knight OnLine Client", dwStyle, 0, 0, iWidth, iHeight, NULL, NULL,


### PR DESCRIPTION
AdjustWindowRect (and AdjustWindowRectEx) already include the necessary system metrics like borders, title bar height (SM_CYCAPTION), and so on  based on the window style you pass in. So manually adding them is not needed. We create the rectangle specify the resolution from the .ini file then we ask AdjustWindowRect to essentially "simulate" the window frame size ahead of time, before actually creating the window — and that’s exactly the intended use case for AdjustWindowRect we then pass the same parameters to the CreateWindow function.
![image](https://github.com/user-attachments/assets/29d7650f-d8ff-4855-a197-f9e4f93ddeac)

💔 Thank you!

### 🚨 Checklist for this Pull Request

- [x] Provide a link to the ticket your pull request addresses or resolves. If there isn't one, create it.
- [x] Ensure you are making a pull request against the **canary branch** (left side). Start *your branch* from *our canary*.
- [x] Verify that your commit messages follow our style guidelines: start with a capitalized verb and limit the title to 72 characters; the description can be longer.
- [x] Ensure your code additions pass linting checks (run the [format.ps1](../format.ps1) script) and avoid irrelevant diffs.
- [x] Ensure your pull request contains isolated changes. Ideally, create separate PRs for unrelated changes.
