### PR TITLE
dwNeedItemFix MagicSkillMng.cpp

### DIFF
--- a/src/game/MagicSkillMng.cpp
+++ b/src/game/MagicSkillMng.cpp
@@ -228,10 +228,12 @@ bool CMagicSkillMng::CheckValidSkillMagic(__TABLE_UPC_SKILL * pSkill) {
     int LeftItem1 = LeftItem / 10;
     int RightItem1 = RightItem / 10;
 
-    if (pSkill->dwNeedItem != 0 && pSkill->dwNeedItem != LeftItem1 && pSkill->dwNeedItem != RightItem1) {
+    if (pSkill->dwNeedItem != 0 && pSkill->dwNeedItem != 9 && pSkill->dwNeedItem != LeftItem1 &&
+        pSkill->dwNeedItem != RightItem1) {
         return false;
     }
-    if (pSkill->dwNeedItem == 0 && (pSkill->dw1stTableType == 1 || pSkill->dw2ndTableType == 1)) {
+    if (pSkill->dwNeedItem == 0 && pSkill->dwNeedItem != 9 &&
+        (pSkill->dw1stTableType == 1 || pSkill->dw2ndTableType == 1)) {
         if (LeftItem != 11 && (LeftItem1 < 1 || LeftItem1 > 5) && RightItem1 != 11 &&
             (RightItem1 < 1 || RightItem1 > 5)) {
             return false;
@@ -588,13 +590,15 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL * pSki
     int LeftItem1 = LeftItem / 10;
     int RightItem1 = RightItem / 10;
 
-    if (pSkill->dwNeedItem != 0 && pSkill->dwNeedItem != LeftItem1 && pSkill->dwNeedItem != RightItem1) {
+    if (pSkill->dwNeedItem != 0 && pSkill->dwNeedItem != 9 && pSkill->dwNeedItem != 9 &&
+        pSkill->dwNeedItem != LeftItem1 && pSkill->dwNeedItem != RightItem1) {
         std::string buff;
         ::_LoadStringFromResource(IDS_SKILL_FAIL_INVALID_ITEM, buff);
         m_pGameProcMain->MsgOutput(buff, 0xffffff00);
         return false;
     }
-    if (pSkill->dwNeedItem == 0 && (pSkill->dw1stTableType == 1 || pSkill->dw2ndTableType == 1)) {
+    if (pSkill->dwNeedItem == 0 && pSkill->dwNeedItem != 9 &&
+        (pSkill->dw1stTableType == 1 || pSkill->dw2ndTableType == 1)) {
         if (LeftItem != 11 && (LeftItem1 < 1 || LeftItem1 > 5) && RightItem1 != 11 &&
             (RightItem1 < 1 || RightItem1 > 5)) {
             std::string buff;

--- a/src/game/MagicSkillMng.cpp
+++ b/src/game/MagicSkillMng.cpp
@@ -209,17 +209,17 @@ bool CMagicSkillMng::CheckValidSkillMagic(__TABLE_UPC_SKILL * pSkill) {
     int LeftItem = s_pPlayer->ItemClass_LeftHand();
     int RightItem = s_pPlayer->ItemClass_RightHand();
 
-    if (pSkill->iNeedSkill == 1055 || pSkill->iNeedSkill == 2055) {
-        if ((LeftItem != ITEM_CLASS_SWORD && LeftItem != ITEM_CLASS_AXE && LeftItem != ITEM_CLASS_MACE) ||
-            (RightItem != ITEM_CLASS_SWORD && RightItem != ITEM_CLASS_AXE && RightItem != ITEM_CLASS_MACE)) {
-            return false;
-        }
-    } else if (pSkill->iNeedSkill == 1056 || pSkill->iNeedSkill == 2056) {
-        if (RightItem != ITEM_CLASS_SWORD_2H && RightItem != ITEM_CLASS_AXE_2H && RightItem != ITEM_CLASS_MACE_2H &&
-            RightItem != ITEM_CLASS_POLEARM) {
-            return false;
-        }
-    }
+    //if (pSkill->iNeedSkill == 1055 || pSkill->iNeedSkill == 2055) {
+    //    if ((LeftItem != ITEM_CLASS_SWORD && LeftItem != ITEM_CLASS_AXE && LeftItem != ITEM_CLASS_MACE) ||
+    //        (RightItem != ITEM_CLASS_SWORD && RightItem != ITEM_CLASS_AXE && RightItem != ITEM_CLASS_MACE)) {
+    //        return false;
+    //    }
+    //} else if (pSkill->iNeedSkill == 1056 || pSkill->iNeedSkill == 2056) {
+    //    if (RightItem != ITEM_CLASS_SWORD_2H && RightItem != ITEM_CLASS_AXE_2H && RightItem != ITEM_CLASS_MACE_2H &&
+    //        RightItem != ITEM_CLASS_POLEARM) {
+    //        return false;
+    //    }
+    //}
 
     if (pInfoBase->iHP < pSkill->iExhaustHP) {
         return false;
@@ -562,7 +562,7 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL * pSki
     int LeftItem = s_pPlayer->ItemClass_LeftHand();
     int RightItem = s_pPlayer->ItemClass_RightHand();
 
-    if (pSkill->iNeedSkill == 1055 || pSkill->iNeedSkill == 2055) {
+    /*if (pSkill->iNeedSkill == 1055 || pSkill->iNeedSkill == 2055) {
         if ((LeftItem != ITEM_CLASS_SWORD && LeftItem != ITEM_CLASS_AXE && LeftItem != ITEM_CLASS_MACE) ||
             (RightItem != ITEM_CLASS_SWORD && RightItem != ITEM_CLASS_AXE && RightItem != ITEM_CLASS_MACE)) {
             std::string buff;
@@ -578,7 +578,7 @@ bool CMagicSkillMng::CheckValidCondition(int iTargetID, __TABLE_UPC_SKILL * pSki
             m_pGameProcMain->MsgOutput(buff, 0xffffff00);
             return false;
         }
-    }
+    }*/
 
     if (pInfoBase->iHP < pSkill->iExhaustHP) {
         std::string buff;


### PR DESCRIPTION
This is a fix to cast skills since the newer tbl's from version roughly 1070+ have a dwNeedItem 9 instead of the original dwNeedItem 0 skills are greyed out and fail to cast even if you equip weapons or class specific items. Also skills that require no items failed to cast with this update we can now cast skills and work further
![image](https://github.com/user-attachments/assets/c0ed4597-d681-45cd-bf2e-73bb8655a2b0)
![image](https://github.com/user-attachments/assets/b64d5a2f-28e4-4b76-ba53-778f8605e311)
![image](https://github.com/user-attachments/assets/7939a5f2-72ac-40d8-b66d-006ea44d06a8)

💔 Thank you!

### 🚨 Checklist for this Pull Request

- [x] Provide a link to the ticket your pull request addresses or resolves. If there isn't one, create it.
- [x] Ensure you are making a pull request against the **canary branch** (left side). Start *your branch* from *our canary*.
- [x] Verify that your commit messages follow our style guidelines: start with a capitalized verb and limit the title to 72 characters; the description can be longer.
- [x] Ensure your code additions pass linting checks (run the [format.ps1](../format.ps1) script) and avoid irrelevant diffs.
- [x] Ensure your pull request contains isolated changes. Ideally, create separate PRs for unrelated changes.
